### PR TITLE
Add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+rvm:
+  - 2.2.2
+install:
+  - bundle install
+  - npm install
+  - cd client && $(npm bin)/webpack --config webpack.rails.config.js


### PR DESCRIPTION
I had to make a few minor changes to get this project to run the acceptance tests in Travis, mostly as a learning exercise.

The most interesting problem I saw was that **es6-promise**, despite being in the `dependencies` section of `client/package.json`, is not installed under `client/node_modules`, instead being nested under `client/node_modules/css-loader/node_modules/postcss/node_modules`, until I added a *duplicate* entry under `devDependencies`; I assume this phenomenon is easily explained, and merely reveals my nascence with node.js.

Thanks for taking a look.