### PR TITLE
Added hint to check that Postgres is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ See package.json and Gemfile for versions
 1. `cd react-webpack-rails-tutorial`
 1. Check that you have Ruby 2.2.2
 1. Check that you're using the right version of node. Run `nvm list` to check.
+1. Check that you have Postgres installed. Run `which postgres` to check.
 1. `bundle install`
 1. `npm install`
 1. `rake db:setup`


### PR DESCRIPTION
The error shown if Postgres is missing is confusing—for me it was along the lines of:

```
Installing pg 0.18.2 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /Users/user/.rbenv/versions/2.2.2/bin/ruby -r ./siteconf20150907-78059-f9x8cq.rb extconf.rb
checking for pg_config... no
No pg_config... trying anyway. If building fails, please try again with
 --with-pg-config=/path/to/pg_config
checking for libpq-fe.h... no
Can't find the 'libpq-fe.h header
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.
```
To save the next person some time, I suggest we add the "check" to the docs.