### PR TITLE
Move jQuery and jQuery-ujs under /client and npm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,7 @@ gem "coffee-rails"
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem "therubyracer", platforms: :ruby
 
-# Use jquery as the JavaScript library
-# gem "jquery-rails"
+# jquery as the JavaScript library has been moved under /client and managed by npm
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem "turbolinks"

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,8 @@ gem "coffee-rails"
 # gem "therubyracer", platforms: :ruby
 
 # Use jquery as the JavaScript library
-gem "jquery-rails"
+# gem "jquery-rails"
+
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem "turbolinks"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,9 @@ gem "coffee-rails"
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem "therubyracer", platforms: :ruby
 
-# jquery as the JavaScript library has been moved under /client and managed by npm
+# jquery as the JavaScript library has been moved under /client and managed by npm.
+# It is critical to not include any of the jquery gems when following this pattern or
+# else you might have multiple jQuery versions.
 
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem "turbolinks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,10 +108,6 @@ GEM
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
-    jquery-rails (4.0.4)
-      rails-dom-testing (~> 1.0)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (1.8.3)
     kgio (2.9.3)
     launchy (2.4.3)
@@ -275,7 +271,6 @@ DEPENDENCIES
   factory_girl_rails
   foreman
   jbuilder
-  jquery-rails
   launchy
   pg
   phantomjs

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ Be sure to see [assets.rake](https://github.com/shakacode/react-webpack-rails-tu
 The `webpack.rails.config.js` file generates client-bundle.js which is then included
 by the Rails asset pipeline.
 
+##jQuery with Rails and Webpack
+jQuery and jQuery-ujs are not required within `app/assets/javascript/application.js`
+and have been moved under`/client` and managed by npm. The modules are exposed as global via entry point
+`script/rails_only.jsx` by `webpack.rails.config.js`.
+
+Please refer to [Considerations for jQuery with Rails and Webpack](http://forum.railsonmaui.com/t/considerations-for-jquery-with-rails-and-webpack/344) for further info.
+
+
 ## Sass and images
 1. The Webpack server loads the images from the **symlink** of the
    `app/assets/images` directory.

--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ by the Rails asset pipeline.
 
 ##jQuery with Rails and Webpack
 jQuery and jQuery-ujs are not required within `app/assets/javascript/application.js`
-and have been moved under`/client` and managed by npm. The modules are exposed as global via entry point
-`script/rails_only.jsx` by `webpack.rails.config.js`.
+and have been moved under`/client` and managed by npm. The modules are exposed via entry point
+by `webpack.common.config.js`.
 
 Please refer to [Considerations for jQuery with Rails and Webpack](http://forum.railsonmaui.com/t/considerations-for-jquery-with-rails-and-webpack/344) for further info.
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ jQuery and jQuery-ujs are not required within `app/assets/javascript/application
 and have been moved under`/client` and managed by npm. The modules are exposed via entry point
 by `webpack.common.config.js`.
 
+In `application.js`, it's critical that any libraries that depend on jQuery come after the inclusion 
+of the Webpack bundle, such as the twitter bootstrap javascript.
+
 Please refer to [Considerations for jQuery with Rails and Webpack](http://forum.railsonmaui.com/t/considerations-for-jquery-with-rails-and-webpack/344) for further info.
 
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,14 +9,11 @@
 //
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
-//
-//= require jquery
-//= require jquery_ujs
 
-//= require bootstrap-sprockets
-
-// Important to import jquery_ujs before rails-bundle as that patches jquery xhr to use the authenticity token!
-
+// Need to be on top to allow Poltergeist test to work with React.
 //= require es5-shim/es5-shim
+
+// It is important that generated/client-bundle must be before bootstrap since it is exposing jQuery and jQuery-ujs
 //= require generated/client-bundle
+//= require bootstrap-sprockets
 //= require turbolinks

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "dependencies": {
     "babel-core": {
-      "version": "5.8.23",
+      "version": "5.8.24",
       "from": "babel-core@>=5.8.23 <6.0.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.23.tgz",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.24.tgz",
       "dependencies": {
         "babel-plugin-constant-folding": {
           "version": "1.0.1",
@@ -95,9 +95,9 @@
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.23.tgz"
         },
         "bluebird": {
-          "version": "2.9.34",
+          "version": "2.10.0",
           "from": "bluebird@>=2.9.33 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.34.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
@@ -734,9 +734,9 @@
           }
         },
         "type-is": {
-          "version": "1.6.6",
+          "version": "1.6.8",
           "from": "type-is@>=1.6.6 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.8.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
@@ -744,14 +744,14 @@
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
-              "version": "2.1.4",
-              "from": "mime-types@>=2.1.4 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.4.tgz",
+              "version": "2.1.6",
+              "from": "mime-types@>=2.1.6 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.6.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.16.0",
-                  "from": "mime-db@>=1.16.0 <1.17.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.16.0.tgz"
+                  "version": "1.18.0",
+                  "from": "mime-db@>=1.18.0 <1.19.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.18.0.tgz"
                 }
               }
             }
@@ -760,9 +760,9 @@
       }
     },
     "es5-shim": {
-      "version": "4.1.12",
+      "version": "4.1.13",
       "from": "es5-shim@>=4.1.12 <5.0.0",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.1.12.tgz"
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.1.13.tgz"
     },
     "es6-promise": {
       "version": "3.0.2",
@@ -771,7 +771,7 @@
     },
     "expose-loader": {
       "version": "0.7.0",
-      "from": "expose-loader@*",
+      "from": "expose-loader@>=0.7.0 <0.8.0",
       "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-0.7.0.tgz"
     },
     "immutable": {
@@ -800,8 +800,13 @@
     },
     "jquery": {
       "version": "2.1.4",
-      "from": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
+      "from": "jquery@>=2.1.4 <3.0.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
+    },
+    "jquery-ujs": {
+      "version": "1.0.4",
+      "from": "jquery-ujs@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.0.4.tgz"
     },
     "loader-utils": {
       "version": "0.2.11",
@@ -825,272 +830,45 @@
       "from": "marked@>=0.3.5 <0.4.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
     },
-    "node-libs-browser": {
-      "version": "0.5.0",
-      "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.0.tgz",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.0.tgz",
-      "dependencies": {
-        "assert": {
-          "version": "1.3.0",
-          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
-        },
-        "browserify-zlib": {
-          "version": "0.1.4",
-          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "dependencies": {
-            "pako": {
-              "version": "0.2.6",
-              "from": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
-            }
-          }
-        },
-        "buffer": {
-          "version": "3.2.2",
-          "from": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz",
-          "dependencies": {
-            "base64-js": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
-            },
-            "ieee754": {
-              "version": "1.1.5",
-              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
-            },
-            "is-array": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
-            }
-          }
-        },
-        "console-browserify": {
-          "version": "1.1.0",
-          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-          "dependencies": {
-            "date-now": {
-              "version": "0.1.4",
-              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-            }
-          }
-        },
-        "constants-browserify": {
-          "version": "0.0.1",
-          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
-        },
-        "crypto-browserify": {
-          "version": "3.2.8",
-          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
-          "dependencies": {
-            "pbkdf2-compat": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
-            },
-            "ripemd160": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
-            },
-            "sha.js": {
-              "version": "2.2.6",
-              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
-              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
-            }
-          }
-        },
-        "domain-browser": {
-          "version": "1.1.4",
-          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
-        },
-        "events": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/events/-/events-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
-        },
-        "http-browserify": {
-          "version": "1.7.0",
-          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
-          "dependencies": {
-            "Base64": {
-              "version": "0.2.1",
-              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "https-browserify": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
-        },
-        "os-browserify": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
-        },
-        "path-browserify": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
-        },
-        "process": {
-          "version": "0.11.0",
-          "from": "https://registry.npmjs.org/process/-/process-0.11.0.tgz",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
-        },
-        "punycode": {
-          "version": "1.3.2",
-          "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-        },
-        "querystring-es3": {
-          "version": "0.2.1",
-          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
-        },
-        "readable-stream": {
-          "version": "1.1.13",
-          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
-          "dependencies": {
-            "core-util-is": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "stream-browserify": {
-          "version": "1.0.0",
-          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-        },
-        "timers-browserify": {
-          "version": "1.4.1",
-          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
-        },
-        "tty-browserify": {
-          "version": "0.0.0",
-          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
-        },
-        "url": {
-          "version": "0.10.3",
-          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-          "dependencies": {
-            "querystring": {
-              "version": "0.2.0",
-              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-            }
-          }
-        },
-        "util": {
-          "version": "0.10.3",
-          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "vm-browserify": {
-          "version": "0.0.4",
-          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-          "dependencies": {
-            "indexof": {
-              "version": "0.0.1",
-              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-            }
-          }
-        }
-      }
-    },
     "react": {
       "version": "0.13.3",
-      "from": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
+      "from": "react@>=0.13.3 <0.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-0.13.3.tgz",
       "dependencies": {
         "envify": {
           "version": "3.4.0",
-          "from": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
+          "from": "envify@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
           "dependencies": {
             "through": {
-              "version": "2.3.7",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+              "version": "2.3.8",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             },
             "jstransform": {
               "version": "10.1.0",
-              "from": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+              "from": "jstransform@>=10.0.1 <11.0.0",
               "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
-                  "from": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz",
+                  "from": "base62@0.1.1",
                   "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
                   "version": "13001.1001.0-dev-harmony-fb",
-                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz",
+                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                  "from": "source-map@0.1.31",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
                   "dependencies": {
                     "amdefine": {
-                      "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
                 }
@@ -1316,7 +1094,7 @@
     },
     "redux-promise": {
       "version": "0.5.0",
-      "from": "redux-promise@*",
+      "from": "redux-promise@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/redux-promise/-/redux-promise-0.5.0.tgz",
       "dependencies": {
         "flux-standard-action": {
@@ -1359,7 +1137,7 @@
     },
     "redux-thunk": {
       "version": "0.1.0",
-      "from": "redux-thunk@*",
+      "from": "redux-thunk@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-0.1.0.tgz"
     },
     "sleep": {
@@ -1368,9 +1146,9 @@
       "resolved": "https://registry.npmjs.org/sleep/-/sleep-3.0.0.tgz",
       "dependencies": {
         "nan": {
-          "version": "2.0.0",
+          "version": "2.0.9",
           "from": "nan@>=2.0.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
         }
       }
     },
@@ -1396,7 +1174,7 @@
           "dependencies": {
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "from": "graceful-fs@>=3.0.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             }
           }
@@ -1425,6 +1203,233 @@
               "version": "0.0.8",
               "from": "minimist@0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.5.2",
+          "from": "node-libs-browser@>=0.4.0 <=0.6.0",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.2.tgz",
+          "dependencies": {
+            "assert": {
+              "version": "1.3.0",
+              "from": "assert@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "browserify-zlib@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.7",
+                  "from": "pako@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "3.4.3",
+              "from": "buffer@>=3.0.3 <4.0.0",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.4.3.tgz",
+              "dependencies": {
+                "base64-js": {
+                  "version": "0.0.8",
+                  "from": "base64-js@0.0.8",
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                },
+                "ieee754": {
+                  "version": "1.1.6",
+                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+                },
+                "is-array": {
+                  "version": "1.0.1",
+                  "from": "is-array@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1",
+              "from": "constants-browserify@0.0.1",
+              "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+            },
+            "crypto-browserify": {
+              "version": "3.2.8",
+              "from": "crypto-browserify@>=3.2.6 <3.3.0",
+              "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+              "dependencies": {
+                "pbkdf2-compat": {
+                  "version": "2.0.1",
+                  "from": "pbkdf2-compat@2.0.1",
+                  "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                },
+                "ripemd160": {
+                  "version": "0.2.0",
+                  "from": "ripemd160@0.2.0",
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.2.6",
+                  "from": "sha.js@2.2.6",
+                  "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.4",
+              "from": "domain-browser@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+            },
+            "events": {
+              "version": "1.0.2",
+              "from": "events@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+            },
+            "http-browserify": {
+              "version": "1.7.0",
+              "from": "http-browserify@>=1.3.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+              "dependencies": {
+                "Base64": {
+                  "version": "0.2.1",
+                  "from": "Base64@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.0",
+              "from": "https-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+            },
+            "os-browserify": {
+              "version": "0.1.2",
+              "from": "os-browserify@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "from": "path-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.11.2",
+              "from": "process@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+            },
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@>=1.2.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "from": "stream-browserify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.25 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "timers-browserify": {
+              "version": "1.4.1",
+              "from": "timers-browserify@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "from": "tty-browserify@0.0.0",
+              "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "url": {
+              "version": "0.10.3",
+              "from": "url@>=0.10.1 <0.11.0",
+              "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+              "dependencies": {
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "querystring@0.2.0",
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "util@>=0.10.3 <0.11.0",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "from": "vm-browserify@0.0.4",
+              "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
             }
           }
         },
@@ -1781,7 +1786,7 @@
                     },
                     "minimatch": {
                       "version": "0.2.14",
-                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "from": "minimatch@>=0.2.12 <0.3.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
@@ -1831,9 +1836,9 @@
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
                   "dependencies": {
                     "nan": {
-                      "version": "2.0.8",
+                      "version": "2.0.9",
                       "from": "nan@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.8.tgz"
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
                     }
                   }
                 }
@@ -1841,7 +1846,7 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "from": "graceful-fs@>=3.0.2 <4.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             }
           }

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "immutable": "^3.7.5",
     "imports-loader": "^0.6.4",
     "jquery": "^2.1.4",
+    "jquery-ujs": "^1.0.4",
     "loader-utils": "^0.2.11",
     "marked": "^0.3.5",
     "react": "^0.13.3",

--- a/client/scripts/rails_only.jsx
+++ b/client/scripts/rails_only.jsx
@@ -8,7 +8,3 @@ require('es5-shim/es5-sham');
 // Due to issue: https://github.com/ariya/phantomjs/issues/12401
 // Phantomjs does not like promises
 require('es6-promise').polyfill();
-
-require('expose?jQuery!jquery');
-require('expose?$!jquery');
-require('expose?jquery-ujs!jquery-ujs');

--- a/client/scripts/rails_only.jsx
+++ b/client/scripts/rails_only.jsx
@@ -8,3 +8,7 @@ require('es5-shim/es5-sham');
 // Due to issue: https://github.com/ariya/phantomjs/issues/12401
 // Phantomjs does not like promises
 require('es6-promise').polyfill();
+
+require('expose?jQuery!jquery');
+require('expose?$!jquery');
+require('expose?jquery-ujs!jquery-ujs');

--- a/client/webpack.common.config.js
+++ b/client/webpack.common.config.js
@@ -8,10 +8,6 @@ module.exports = {
   context: __dirname,
   entry: ['./assets/javascripts/App'],
 
-  // In case you wanted to load jQuery from the CDN, this is how you would do it:
-  // externals: {
-  //   jquery: 'var jQuery'
-  // },
   resolve: {
     root: [
       path.join(__dirname, 'scripts'),

--- a/client/webpack.common.config.js
+++ b/client/webpack.common.config.js
@@ -6,7 +6,7 @@ module.exports = {
 
   // the project dir
   context: __dirname,
-  entry: ['./assets/javascripts/App'],
+  entry: ['jquery', 'jquery-ujs', './assets/javascripts/App'],
 
   resolve: {
     root: [
@@ -20,6 +20,7 @@ module.exports = {
 
       // React is necessary for the client rendering:
       {test: require.resolve('react'), loader: 'expose?React'},
+      {test: require.resolve('jquery'), loader: 'expose?jQuery'}
     ],
   },
 };

--- a/client/webpack.common.config.js
+++ b/client/webpack.common.config.js
@@ -21,6 +21,7 @@ module.exports = {
       // React is necessary for the client rendering:
       {test: require.resolve('react'), loader: 'expose?React'},
       {test: require.resolve('jquery'), loader: 'expose?jQuery'},
+      {test: require.resolve('jquery'), loader: 'expose?$'},
     ],
   },
 };

--- a/client/webpack.common.config.js
+++ b/client/webpack.common.config.js
@@ -20,7 +20,7 @@ module.exports = {
 
       // React is necessary for the client rendering:
       {test: require.resolve('react'), loader: 'expose?React'},
-      {test: require.resolve('jquery'), loader: 'expose?jQuery'}
+      {test: require.resolve('jquery'), loader: 'expose?jQuery'},
     ],
   },
 };

--- a/client/webpack.rails.config.js
+++ b/client/webpack.rails.config.js
@@ -11,9 +11,6 @@ config.output = {
   path: '../app/assets/javascripts/generated',
 };
 
-// load jQuery from cdn or rails asset pipeline
-// config.externals = {jquery: 'var jQuery'};
-
 // You can add entry points specific to rails here
 config.entry.push('./scripts/rails_only');
 

--- a/client/webpack.rails.config.js
+++ b/client/webpack.rails.config.js
@@ -12,7 +12,7 @@ config.output = {
 };
 
 // load jQuery from cdn or rails asset pipeline
-config.externals = {jquery: 'var jQuery'};
+// config.externals = {jquery: 'var jQuery'};
 
 // You can add entry points specific to rails here
 config.entry.push('./scripts/rails_only');
@@ -20,12 +20,7 @@ config.entry.push('./scripts/rails_only');
 // See webpack.common.config for adding modules common to both the webpack dev server and rails
 
 config.module.loaders.push(
-  {test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel-loader'},
-
-  // Next 2 lines expose jQuery and $ to any JavaScript files loaded after client-bundle.js
-  // in the Rails Asset Pipeline. Thus, load this one prior.
-  {test: require.resolve('jquery'), loader: 'expose?jQuery'},
-  {test: require.resolve('jquery'), loader: 'expose?$'}
+  {test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel-loader'}
 );
 module.exports = config;
 


### PR DESCRIPTION
Comment out jquery-rails gem
Remove require for jQuery and jQuery-ujs from application.js
Change required order of application.js client-bundle and es5-shim
Add jquery-ujs to package.json and npm shrinkwrap
Remove comments about jQuery from webpack.common.config.js
Remove jQuery loader expose from webpack.rails.config.js
Comment out jQuery import or external jQuery since it is served from
/client.
Move jQuery and jQuery-ujs expose to via require to rails_only.jsx entry point.
Add info to README about using jQuery with Rails and Webpack
This fixes #51 