### PR TITLE
Update npm module jquery-ujs to 1.1.0-1, npm shrinkwrap

### DIFF
--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "dependencies": {
     "babel-core": {
-      "version": "5.8.24",
+      "version": "5.8.25",
       "from": "babel-core@>=5.8.23 <6.0.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.24.tgz",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.25.tgz",
       "dependencies": {
         "babel-plugin-constant-folding": {
           "version": "1.0.1",
@@ -378,9 +378,9 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.5",
+                          "version": "2.7.0",
                           "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
@@ -651,9 +651,9 @@
       }
     },
     "body-parser": {
-      "version": "1.13.3",
+      "version": "1.14.0",
       "from": "body-parser@>=1.13.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.0.tgz",
       "dependencies": {
         "bytes": {
           "version": "2.1.0",
@@ -678,9 +678,9 @@
           }
         },
         "depd": {
-          "version": "1.0.1",
-          "from": "depd@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+          "version": "1.1.0",
+          "from": "depd@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "http-errors": {
           "version": "1.3.1",
@@ -717,14 +717,14 @@
           }
         },
         "qs": {
-          "version": "4.0.0",
-          "from": "qs@4.0.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
+          "version": "5.1.0",
+          "from": "qs@5.1.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz"
         },
         "raw-body": {
-          "version": "2.1.2",
-          "from": "raw-body@>=2.1.2 <2.2.0",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.2.tgz",
+          "version": "2.1.3",
+          "from": "raw-body@>=2.1.3 <2.2.0",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.3.tgz",
           "dependencies": {
             "unpipe": {
               "version": "1.0.0",
@@ -735,7 +735,7 @@
         },
         "type-is": {
           "version": "1.6.8",
-          "from": "type-is@>=1.6.6 <1.7.0",
+          "from": "type-is@>=1.6.8 <1.7.0",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.8.tgz",
           "dependencies": {
             "media-typer": {
@@ -804,9 +804,9 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz"
     },
     "jquery-ujs": {
-      "version": "1.0.4",
-      "from": "jquery-ujs@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.0.4.tgz"
+      "version": "1.1.0-1",
+      "from": "jquery-ujs@>=1.1.0-1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.1.0-1.tgz"
     },
     "loader-utils": {
       "version": "0.2.11",
@@ -879,14 +879,14 @@
       }
     },
     "react-bootstrap": {
-      "version": "0.25.1",
+      "version": "0.25.2",
       "from": "react-bootstrap@>=0.25.1 <0.26.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.25.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.25.2.tgz",
       "dependencies": {
         "babel-runtime": {
-          "version": "5.8.20",
+          "version": "5.8.24",
           "from": "babel-runtime@>=5.8.19 <6.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.20.tgz",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.24.tgz",
           "dependencies": {
             "core-js": {
               "version": "1.1.4",
@@ -976,9 +976,9 @@
           }
         },
         "uncontrollable": {
-          "version": "3.1.0",
+          "version": "3.1.2",
           "from": "uncontrollable@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-3.1.2.tgz",
           "dependencies": {
             "invariant": {
               "version": "2.1.0",
@@ -1033,9 +1033,9 @@
       }
     },
     "react-redux": {
-      "version": "2.1.1",
+      "version": "2.1.2",
       "from": "react-redux@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-2.1.2.tgz",
       "dependencies": {
         "invariant": {
           "version": "2.1.0",
@@ -1153,9 +1153,9 @@
       }
     },
     "webpack": {
-      "version": "1.12.1",
+      "version": "1.12.2",
       "from": "webpack@>=1.12.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.1.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.2.tgz",
       "dependencies": {
         "async": {
           "version": "1.4.2",
@@ -1207,9 +1207,9 @@
           }
         },
         "node-libs-browser": {
-          "version": "0.5.2",
+          "version": "0.5.3",
           "from": "node-libs-browser@>=0.4.0 <=0.6.0",
-          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
           "dependencies": {
             "assert": {
               "version": "1.3.0",
@@ -1222,16 +1222,16 @@
               "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
-                  "version": "0.2.7",
+                  "version": "0.2.8",
                   "from": "pako@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
                 }
               }
             },
             "buffer": {
-              "version": "3.4.3",
+              "version": "3.5.0",
               "from": "buffer@>=3.0.3 <4.0.0",
-              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.0.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "0.0.8",
@@ -1534,9 +1534,9 @@
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
             "chokidar": {
-              "version": "1.0.5",
+              "version": "1.0.6",
               "from": "chokidar@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.6.tgz",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
@@ -1748,9 +1748,16 @@
                   "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
                 },
                 "glob-parent": {
-                  "version": "1.2.0",
+                  "version": "1.3.0",
                   "from": "glob-parent@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
+                  "dependencies": {
+                    "is-glob": {
+                      "version": "2.0.0",
+                      "from": "is-glob@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.0.tgz"
+                    }
+                  }
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
@@ -1790,9 +1797,9 @@
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.6.5",
-                          "from": "lru-cache@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.5.tgz"
+                          "version": "2.7.0",
+                          "from": "lru-cache@>=2.6.5 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
                         },
                         "sigmund": {
                           "version": "1.0.1",
@@ -1832,7 +1839,7 @@
                 },
                 "fsevents": {
                   "version": "0.3.8",
-                  "from": "fsevents@>=0.3.1 <0.4.0",
+                  "from": "fsevents@>=0.3.8 <0.4.0",
                   "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
                   "dependencies": {
                     "nan": {
@@ -1852,9 +1859,9 @@
           }
         },
         "webpack-core": {
-          "version": "0.6.6",
+          "version": "0.6.7",
           "from": "webpack-core@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.6.tgz",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.7.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.4",

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
     "immutable": "^3.7.5",
     "imports-loader": "^0.6.4",
     "jquery": "^2.1.4",
-    "jquery-ujs": "^1.0.4",
+    "jquery-ujs": "^1.1.0-1",
     "loader-utils": "^0.2.11",
     "marked": "^0.3.5",
     "react": "^0.13.3",


### PR DESCRIPTION
Bump up npm module jquery-ujs to latest release 1.1.0-1.
npm shrinkwrap due to module update.