### PR TITLE
Updated ci.rake usage of brakeman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,9 +53,6 @@ group :production do
 end
 
 group :development, :test do
-  # Call "debugger" anywhere in the code to stop execution and get a debugger console
-  gem "byebug"
-
   # Access an IRB console on exceptions page and /console in development
   gem "web-console"
 
@@ -80,6 +77,14 @@ group :development, :test do
   gem "bundler-audit", require: false
 
   gem "rainbow"
+
+  # Favorite debugging gems
+  gem "pry"
+  gem "pry-doc"
+  gem "pry-rails"
+  gem "pry-stack_explorer"
+  gem "pry-rescue"
+  gem "pry-byebug"
 end
 
 group :test  do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,15 +52,16 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
-    brakeman (3.0.5)
+    brakeman (3.1.1)
       erubis (~> 2.6)
       fastercsv (~> 1.5)
       haml (>= 3.0, < 5.0)
-      highline (~> 1.6.20)
+      highline (~> 1.6)
       multi_json (~> 1.2)
-      ruby2ruby (~> 2.1.1)
+      ruby2ruby (>= 2.1.1, < 2.3.0)
       ruby_parser (~> 3.7.0)
       sass (~> 3.0)
+      slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
     bundler-audit (0.4.0)
@@ -82,6 +83,7 @@ GEM
     chromedriver-helper (1.0.0)
       archive-zip (~> 0.7.0)
       nokogiri (~> 1.6)
+    coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -118,12 +120,13 @@ GEM
       thor (~> 0.19.1)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
-    haml (4.0.6)
+    haml (4.0.7)
       tilt
-    highline (1.6.21)
+    highline (1.7.7)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
+    interception (0.5)
     io-like (0.3.0)
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
@@ -137,6 +140,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
@@ -148,6 +152,24 @@ GEM
       ast (>= 1.1, < 3.0)
     pg (0.18.2)
     powerpack (0.1.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.2.0)
+      byebug (~> 5.0)
+      pry (~> 0.10)
+    pry-doc (0.8.0)
+      pry (~> 0.9)
+      yard (~> 0.8)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
+    pry-rescue (1.4.2)
+      interception (>= 0.5)
+      pry
+    pry-stack_explorer (0.4.9.2)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -219,13 +241,13 @@ GEM
       parser (~> 2.2)
       slop (~> 3.4, >= 3.4.7)
     ruby-progressbar (1.7.5)
-    ruby2ruby (2.1.4)
+    ruby2ruby (2.2.0)
       ruby_parser (~> 3.1)
       sexp_processor (~> 4.0)
-    ruby_parser (3.7.0)
+    ruby_parser (3.7.1)
       sexp_processor (~> 4.1)
     rubyzip (1.1.7)
-    sass (3.4.16)
+    sass (3.4.18)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -249,6 +271,9 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slim (3.0.6)
+      temple (~> 0.7.3)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
@@ -260,6 +285,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.10)
+    temple (0.7.6)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     terminal-table (1.5.2)
@@ -292,6 +318,7 @@ GEM
     websocket (1.2.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -302,7 +329,6 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.1)
   brakeman
   bundler-audit
-  byebug
   capybara
   capybara-screenshot
   chromedriver-helper
@@ -315,6 +341,12 @@ DEPENDENCIES
   jbuilder
   launchy
   pg
+  pry
+  pry-byebug
+  pry-doc
+  pry-rails
+  pry-rescue
+  pry-stack_explorer
   rails (~> 4.2)
   rails-html-sanitizer
   rails_12factor

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -8,7 +8,8 @@ if Rails.env.development?
 
   task :security_audit do
     puts Rainbow("Running security audit on code (brakeman)").green
-    Rake::Task["brakeman:run"].invoke("tmp/brakeman-report.html")
+
+    sh "brakeman --exit-on-warn --quiet -A"
   end
 
   namespace :ci do
@@ -29,5 +30,4 @@ if Rails.env.development?
   task ci: "ci:all"
 
   task(:default).clear.enhance([:ci])
-
 end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -9,7 +9,7 @@ if Rails.env.development?
   task :security_audit do
     puts Rainbow("Running security audit on code (brakeman)").green
 
-    sh "brakeman --exit-on-warn --quiet -A"
+    sh "brakeman --exit-on-warn --quiet -A -z"
   end
 
   namespace :ci do


### PR DESCRIPTION
* Run brakeman like:
  `brakeman --exit-on-warn --quiet -A`
* This makes ci fail if there's a brakeman issue.
* Updated brakeman gem to current (3.1.1)
* Bonus: Added pry debugging gems