### PR TITLE
Unify use of jbuilder with server rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,33 +260,24 @@ cd client && npm run build:client && npm run build:server
 
 # JBuilder Notes
 There's a bunch of gotchas with using [Jbuilder](https://github.com/rails/jbuilder) to create the
-string version of the props to be sent to the react_on_rails_gem:
+string version of the props to be sent to the react_on_rails_gem. The main thing is that if you
+follow the example and call Jbuilder like this, you don't run into a number of issues.
 
-See the notes in this the example code. The two critical things:
+```erb
+<%= react_component('App', render(template: "/comments/index.json.jbuilder"),
+    generator_function: true, prerender: true) %>
+```
+
+However, if you try to set the value of the JSON string inside of the controller, then you will 
+run into several issues with rendering the Jbuilder template from the controller.
+See the notes in this the example code for app/controllers/pages_controller.rb.
+
+The two critical things:
 
 1. Use `render_to_string` to create string of JSON.
 2. Be sure to call `respond_to` afterwards. 
 
-app/controllers/pages_controller.rb
-
-```ruby
-   class PagesController < ApplicationController
-     def index
-       # NOTE: this could be an alternate syntax if you wanted to pass comments as a variable to a partial
-       # @comments_json_string = render_to_string(partial: "/comments/comments.json.jbuilder", locals: { comments: Comment.all }, format: :json)
-       @comments = Comment.all
-   
-       # NOTE: @comments is used by the render_to_string call
-       @comments_json_string = render_to_string("/comments/index.json.jbuilder")
-   
-       # NOTE: It's CRITICAL to call respond_to after calling render_to_string, or else Rails will
-       # not render the HTML version of the index page properly.
-       respond_to do |format|
-         format.html
-       end
-     end
-   end
-```
+Here's the samples of Jbuilder that we use:
 
 ### comments/_comment.json.jbuilder:
 

--- a/README.md
+++ b/README.md
@@ -272,11 +272,6 @@ However, if you try to set the value of the JSON string inside of the controller
 run into several issues with rendering the Jbuilder template from the controller.
 See the notes in this the example code for app/controllers/pages_controller.rb.
 
-The two critical things:
-
-1. Use `render_to_string` to create string of JSON.
-2. Be sure to call `respond_to` afterwards. 
-
 Here's the samples of Jbuilder that we use:
 
 ### comments/_comment.json.jbuilder:

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,17 +1,24 @@
 class PagesController < ApplicationController
   def index
+    @comments = Comment.all
+
+    # NOTE: The below notes apply if you want to set the value of the props in the controller, as
+    # compared to he view. However, it's more convenient to use Jbuilder from the view. See
+    # app/views/pages/index.html.erb:20
+    #
+    #  <%= react_component('App', render(template: "/comments/index.json.jbuilder"),
+    #     generator_function: true, prerender: true) %>
+    #
+    #
     # NOTE: this could be an alternate syntax if you wanted to pass comments as a variable to a partial
     # @comments_json_sting = render_to_string(partial: "/comments/comments.json.jbuilder",
     #                                         locals: { comments: Comment.all }, format: :json)
-    @comments = Comment.all
-
     # NOTE: @comments is used by the render_to_string call
-    @comments_json_string = render_to_string("/comments/index.json.jbuilder")
-
+    # @comments_json_string = render_to_string("/comments/index.json.jbuilder")
     # NOTE: It's CRITICAL to call respond_to after calling render_to_string, or else Rails will
-    # not render the HTML version of the index page properly.
-    respond_to do |format|
-      format.html
-    end
+    # not render the HTML version of the index page properly. (not a problem if you do this in the view)
+    # respond_to do |format|
+    #   format.html
+    # end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,17 @@
 class PagesController < ApplicationController
   def index
+    # NOTE: this could be an alternate syntax if you wanted to pass comments as a variable to a partial
+    # @comments_json_sting = render_to_string(partial: "/comments/comments.json.jbuilder",
+    #                                         locals: { comments: Comment.all }, format: :json)
     @comments = Comment.all
+
+    # NOTE: @comments is used by the render_to_string call
+    @comments_json_string = render_to_string("/comments/index.json.jbuilder")
+
+    # NOTE: It's CRITICAL to call respond_to after calling render_to_string, or else Rails will
+    # not render the HTML version of the index page properly.
+    respond_to do |format|
+      format.html
+    end
   end
 end

--- a/app/views/comments/_comment.json.jbuilder
+++ b/app/views/comments/_comment.json.jbuilder
@@ -1,0 +1,1 @@
+json.extract! comment, :id, :author, :text, :created_at, :updated_at

--- a/app/views/comments/index.json.jbuilder
+++ b/app/views/comments/index.json.jbuilder
@@ -1,4 +1,2 @@
-json.array!(@comments) do |comment|
-  json.extract! comment, :id, :author, :text
-  json.url comment_url(comment, format: :json)
-end
+# Specify the partial, as well as the name of the variable used in the partial
+json.array! @comments, { partial: "comments/comment", as: :comment }

--- a/app/views/comments/show.json.jbuilder
+++ b/app/views/comments/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @comment, :id, :author, :text, :created_at, :updated_at
+json.partial! 'comment', comment: @comment

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -16,4 +16,6 @@
   </li>
 </ul>
 <hr/>
-<%= react_component('App', @comments_json_string, generator_function: true, prerender: true) %>
+
+<%= react_component('App', render(template: "/comments/index.json.jbuilder"),
+    generator_function: true, prerender: true) %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -3,10 +3,10 @@
   <li>
     If this work interests you and you're a developer or designer looking for full or part-time remote work: please
     <%= link_to "click here",
-      "http://forum.railsonmaui.com/t/railsonmaui-is-hiring-and-partnering-part-time-remote-is-ok/156" %>
+      "http://forum.shakacode.com/t/railsonmaui-is-hiring-and-partnering-part-time-remote-is-ok/156/3" %>
     and
     <%= link_to "here",
-     "http://forum.railsonmaui.com/t/railsonmaui-is-hiring-and-partnering-part-time-remote-is-ok/156/2" %>.
+     "http://forum.shakacode.com/t/railsonmaui-is-hiring-and-partnering-part-time-remote-is-ok/156/2" %>.
   </li>
   <li>
     Please see the
@@ -16,4 +16,4 @@
   </li>
 </ul>
 <hr/>
-<%= react_component('App', @comments, generator_function: true, prerender: true) %>
+<%= react_component('App', @comments_json_string, generator_function: true, prerender: true) %>


### PR DESCRIPTION
* Change to use the same JSON for the server side load and the client
  side load of the comments.
* Reuse one jbuilder template for the list and single view of comments.
* Update the docs with how to do this.