### PR TITLE
Ci build issues

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,7 @@ RSpec.configure do |config|
     end
   end
 
+  Capybara.default_wait_time = 15
   puts "Capybara using driver: #{Capybara.javascript_driver}"
 
   Capybara::Screenshot.prune_strategy = { keep: 10 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,11 +56,19 @@ RSpec.configure do |config|
       Capybara::Selenium::Driver.new(app, browser: :chrome)
     end
     Capybara.javascript_driver = :selenium_chrome
+
+    Capybara::Screenshot.register_driver(:selenium_chrome) do |driver, path|
+      driver.browser.save_screenshot(path)
+    end
   else
     Capybara.register_driver :selenium_firefox do |app|
       Capybara::Selenium::Driver.new(app, browser: :firefox)
     end
     Capybara.javascript_driver = :selenium_firefox
+
+    Capybara::Screenshot.register_driver(:selenium_firefox) do |driver, path|
+      driver.browser.save_screenshot(path)
+    end
   end
 
   puts "Capybara using driver: #{Capybara.javascript_driver}"


### PR DESCRIPTION
Fix capybara screenshot render during failing tests by assigning the custom js driver.
Add capybara default_wait_time per Travis CI common build errors: 

http://docs.travis-ci.com/user/common-build-problems/#Capybara%3A-I%E2%80%99m-getting-errors-about-elements-not-being-found