### PR TITLE
Fix warnings of upgrading to React 0.14

### DIFF
--- a/client/app/components/CommentForm.jsx
+++ b/client/app/components/CommentForm.jsx
@@ -225,8 +225,11 @@ const CommentForm = React.createClass({
     }
     return (
       <div>
-
-        <ReactCSSTransitionGroup transitionName="element">
+        <ReactCSSTransitionGroup
+          transitionName="element"
+          transitionEnterTimeout={300}
+          transitionLeaveTimeout={300}
+        >
           {this.errorWarning()}
         </ReactCSSTransitionGroup>
 

--- a/client/app/components/CommentList.jsx
+++ b/client/app/components/CommentList.jsx
@@ -41,7 +41,11 @@ const CommentList = React.createClass({
 
     return (
       <div>
-        <ReactCSSTransitionGroup transitionName="element">
+        <ReactCSSTransitionGroup
+          transitionName="element"
+          transitionEnterTimeout={300}
+          transitionLeaveTimeout={300}
+        >
           {this.errorWarning()}
         </ReactCSSTransitionGroup>
         <div className="commentList">

--- a/client/app/startup/ClientApp.jsx
+++ b/client/app/startup/ClientApp.jsx
@@ -8,7 +8,7 @@ const App = props => {
   const store = createStore(props);
   const reactComponent = (
     <Provider store={store}>
-      {() => <CommentScreen />}
+      <CommentScreen />
     </Provider>
   );
   return reactComponent;

--- a/client/app/startup/ServerApp.jsx
+++ b/client/app/startup/ServerApp.jsx
@@ -8,7 +8,7 @@ const App = props => {
   const store = createStore(props);
   const reactComponent = (
     <Provider store={store}>
-      {() => <CommentScreen />}
+      <CommentScreen />
     </Provider>
   );
   return reactComponent;

--- a/client/index.jade
+++ b/client/index.jade
@@ -11,4 +11,4 @@ html
     script(src="vendor-bundle.js")
     script(src="app-bundle.js")
     script.
-      React.render(App(!{props}), document.getElementById('app'));
+      ReactDOM.render(App(!{props}), document.getElementById('app'));

--- a/client/webpack.client.base.config.js
+++ b/client/webpack.client.base.config.js
@@ -29,6 +29,7 @@ module.exports = {
 
       // React is necessary for the client rendering:
       {test: require.resolve('react'), loader: 'expose?React'},
+      {test: require.resolve('react-dom'), loader: 'expose?ReactDOM'},
       {test: require.resolve('jquery'), loader: 'expose?jQuery'},
       {test: require.resolve('jquery'), loader: 'expose?$'},
     ],


### PR DESCRIPTION
- New required propTypes for `ReactCSSTransitionGroup`
- Provider component doesn't need to wrap a function anymore
- The `render` method now belongs to the `ReactDOM` lib