### PR TITLE
We need this as well for proper 0.14 server support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "rails-html-sanitizer"
 # Use Unicorn as the app server
 gem "unicorn"
 
-gem "react_on_rails", "~> 0.1.8"
+gem "react_on_rails", "~> 1.0.0.pre"
 gem "therubyracer"
 
 gem "autoprefixer-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,7 +207,7 @@ GEM
     raindrops (0.15.0)
     rake (10.4.2)
     rdoc (4.2.0)
-    react_on_rails (0.1.8)
+    react_on_rails (1.0.0.pre)
       connection_pool
       execjs (~> 2.5)
       rails (>= 4.0)
@@ -353,7 +353,7 @@ DEPENDENCIES
   rails-html-sanitizer
   rails_12factor
   rainbow
-  react_on_rails (~> 0.1.8)
+  react_on_rails (~> 1.0.0.pre)
   rspec-rails
   rubocop
   ruby-lint

--- a/client/README.md
+++ b/client/README.md
@@ -39,9 +39,10 @@ Updating Node Dependencies
 npm install -g npm-check-updates
 ```
  
-  
+Then run this to update the dependencies (starting at the top level).
+
 ```
-# Make sure you are in the `client` directory, then run:
+# Make sure you are in the top directory, then run:
 cd client 
 rm npm-shrinkwrap.json
 npm-check-updates -u

--- a/client/webpack.server.rails.config.js
+++ b/client/webpack.server.rails.config.js
@@ -27,6 +27,7 @@ module.exports = {
 
       // React is necessary for the client rendering:
       {test: require.resolve('react'), loader: 'expose?React'},
+      {test: require.resolve('react-dom/server'), loader: 'expose?ReactDOMServer'},
     ],
   },
 };


### PR DESCRIPTION
Have to expose ReactDOMServer as well for the server rendering per 0.14 upgrade docs.