### PR TITLE
Reverse ports of Webpack and Rails server

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: rails s -p 4000
+web: rails s
 client: sh -c 'rm app/assets/javascripts/generated/* || true && cd client && npm run build:dev:client'
 server: sh -c 'cd client && npm run build:dev:server'
 hot: sh -c 'cd client && npm start'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In no particular order:
 
 - Example of using the [react_on_rails](https://github.com/shakacode/react_on_rails)
 - Example of Rails 4.2 with ReactJs/Redux with Webpack and ES7.
-- Enable development of a JS client independently from Rails using Webpack Hot Module Reload. You can see this by starting the app and visiting http://localhost:3000
+- Enable development of a JS client independently from Rails using Webpack Hot Module Reload. You can see this by starting the app and visiting http://localhost:4000
 - Easily enable use of npm modules with a Rails application.
 - Easily enable retrofitting such a JS framework into an existing Rails app.
 - Enable the use of the JavaScript ES7 transpiler.
@@ -72,8 +72,8 @@ See package.json and Gemfile for versions
 1. `npm install`
 1. `rake db:setup`
 1. `foreman start -f Procfile.dev`
-1. Open a browser tab to http://0.0.0.0:4000 for the Rails app example.
-1. Open a browser tab to http://0.0.0.0:3000 for the Hot Module Replacement Example.
+1. Open a browser tab to http://0.0.0.0:3000 for the Rails app example.
+1. Open a browser tab to http://0.0.0.0:4000 for the Hot Module Replacement Example.
 
 # Javascript development without Rails using Hot Module Replacement (HMR)
 
@@ -84,7 +84,7 @@ cd client
 node server.js
 ```
 
-Point your browser to http://0.0.0.0:3000.
+Point your browser to http://0.0.0.0:4000.
 
 Save a change to a JSX file and see it update immediately in the browser! Note,
 any browser state still exists, such as what you've typed in the comments box.
@@ -118,10 +118,10 @@ the Rails server.
 ```
 cd <rails_project_name>
 rake db:setup
-rails s -p 4000
+rails s
 ```
 
-Now point your browser to http://0.0.0.0:4000.
+Now point your browser to http://0.0.0.0:3000.
 
 Note that it's important to run the Rails server on a different port than the node server.
 
@@ -267,7 +267,7 @@ follow the example and call Jbuilder like this, you don't run into a number of i
     generator_function: true, prerender: true) %>
 ```
 
-However, if you try to set the value of the JSON string inside of the controller, then you will 
+However, if you try to set the value of the JSON string inside of the controller, then you will
 run into several issues with rendering the Jbuilder template from the controller.
 See the notes in this the example code for app/controllers/pages_controller.rb.
 

--- a/client/server.js
+++ b/client/server.js
@@ -51,7 +51,7 @@ server.app.use('/', function(req, res) {
   res.send(html);
 });
 
-server.listen(3000, 'localhost', function(err) {
+server.listen(4000, 'localhost', function(err) {
   if (err) console.log(err);
-  console.log('Listening at localhost:3000...');
+  console.log('Listening at localhost:4000...');
 });

--- a/client/webpack.client.hot.config.js
+++ b/client/webpack.client.hot.config.js
@@ -11,7 +11,7 @@ config.entry.vendor.push('bootstrap-sass!./bootstrap-sass.config.js');
 config.entry.app.push(
 
   // Webpack dev server
-  'webpack-dev-server/client?http://localhost:3000',
+  'webpack-dev-server/client?http://localhost:4000',
   'webpack/hot/dev-server',
 
   // Test out Css & Sass

--- a/spec/requests/server_render_check_spec.rb
+++ b/spec/requests/server_render_check_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "Server Rendering" do
+  it "generates server rendered HTML if server rendering enabled" do
+    get root_path
+    html_nodes = Nokogiri::HTML(response.body)
+    expect(html_nodes.css("div#App-react-component-0").children.size).to eq(1)
+    expect(html_nodes.css("div#App-react-component-0 h2").text)
+      .to include("Comments")
+  end
+
+  it "generates no server rendered HTML if server rendering not enabled" do
+    get simple_path
+    html_nodes = Nokogiri::HTML(response.body)
+    expect(html_nodes.css("div#SimpleCommentScreen-react-component-0").children.size).to eq(0)
+  end
+end


### PR DESCRIPTION
This fixes #116.

- Change Rails server port to default (3000).
- Change Webpack dev server port to 4000.
- Add simple server rendering tests