### PR TITLE
Set comment's author and text as not null and defaults as empty string

### DIFF
--- a/db/migrate/20151015160035_set_default_for_author_and_text.rb
+++ b/db/migrate/20151015160035_set_default_for_author_and_text.rb
@@ -1,0 +1,11 @@
+class SetDefaultForAuthorAndText < ActiveRecord::Migration
+  def up
+    change_column_default(:comments, :author, "")
+    change_column_default(:comments, :text, "")
+  end
+
+  def down
+    change_column_default(:comments, :author, nil)
+    change_column_default(:comments, :text, nil)
+  end
+end

--- a/db/migrate/20151015160334_change_author_and_text_to_not_null.rb
+++ b/db/migrate/20151015160334_change_author_and_text_to_not_null.rb
@@ -1,0 +1,6 @@
+class ChangeAuthorAndTextToNotNull < ActiveRecord::Migration
+  def change
+    change_column_null(:comments, :author, false, "")
+    change_column_null(:comments, :text, false, "")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140823052830) do
+ActiveRecord::Schema.define(version: 20151015160334) do
 
   create_table "comments", force: :cascade do |t|
-    t.string   "author"
-    t.text     "text"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "author",     default: "", null: false
+    t.text     "text",       default: "", null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
   end
 
 end


### PR DESCRIPTION
The last parameter of `change_column_null` only affects existing records, thus the new default value still needed to be set by `change_column_default`.

Fixes #110.