### PR TITLE
Change calls of ReactOnRails to Rails.application

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -18,7 +18,7 @@ namespace :assets do
   end
 
   task :clobber do
-    rm_rf "#{RailsReactTutorial::Application.config.root}/app/assets/javascripts/generated/client-bundle.js"
-    rm_rf "#{RailsReactTutorial::Application.config.root}/app/assets/javascripts/generated/server-bundle.js"
+    rm_rf "#{Rails.application.config.root}/app/assets/javascripts/generated/client-bundle.js"
+    rm_rf "#{Rails.application.config.root}/app/assets/javascripts/generated/server-bundle.js"
   end
 end


### PR DESCRIPTION
Ensure that users copying example files won't run into issues due to references to `RailsReactTutorial::Application`, which obviously won't be the name of their app. Instead, use `Rails.application`. This reflects similar changes in https://github.com/shakacode/react_on_rails/pull/53

Besides the actual `config/application.rb` file and the `<title>` element of the main layout, I found no other occurrences.