### PR TITLE
Remove es5-shim from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,6 @@ gem "turbolinks"
 gem "jbuilder"
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", group: :doc
-gem "es5-shim-rails"
 
 # Use ActiveModel has_secure_password
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,9 +106,6 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    es5-shim-rails (4.0.1)
-      actionpack (>= 3.1)
-      railties (>= 3.1)
     execjs (2.5.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -337,7 +334,6 @@ DEPENDENCIES
   coffee-rails
   coveralls
   database_cleaner
-  es5-shim-rails
   factory_girl_rails
   foreman
   jbuilder


### PR DESCRIPTION
No longer necessary as we are relying on Webpack to use its own es5-shim loader.

Thanks to @hisapy: https://github.com/shakacode/react-webpack-rails-tutorial/pull/131#issuecomment-152184021