### PR TITLE
Fix ci build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 addons:
   apt:
     sources:
-      ubuntu-toolchain-r/test
+      ubuntu-toolchain-r-test
     packages:
       g++-4.9
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 before_install:
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update -q
-  - sudo apt-get install gcc-4.9 -y
+  - sudo apt-get install g++-4.9 -y
 env:
   global:
     - RAILS_ENV=test
@@ -14,7 +14,6 @@ install:
   - bundle install
   - nvm install 5.0
   - nvm use 5.0
-  - npm install -g npm
   - npm install
   - cd client && npm run build:client
   - npm run build:server

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,14 @@ language:
   - ruby
 rvm:
   - 2.2.3
+before_install:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -q
+  - sudo apt-get install gcc-4.9 -y
 env:
-  - export RAILS_ENV=test
-  - CXX=g++-4.9
+  global:
+    - RAILS_ENV=test
+    - CXX=g++-4.9
 install:
   - bundle install
   - nvm install 5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,13 @@ language:
   - ruby
 rvm:
   - 2.2.3
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -q
-  - sudo apt-get install g++-4.9 -y
+sudo: false
+addons:
+  apt:
+    sources:
+      ubuntu-toolchain-r/test
+    packages:
+      g++-4.9
 env:
   global:
     - RAILS_ENV=test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language:
   - ruby
 rvm:
   - 2.2.3
+env:
+  - export RAILS_ENV=test
+  - CXX=g++-4.9
 install:
   - bundle install
   - nvm install 5.0
@@ -10,8 +13,6 @@ install:
   - npm install
   - cd client && npm run build:client
   - npm run build:server
-env:
-  - export RAILS_ENV=test
 before_script:
    - export DISPLAY=:99.0
    - sh -e /etc/init.d/xvfb start

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -40,7 +40,7 @@ rules:
   react/no-did-update-set-state: 0
   react/no-multi-comp: 2
   react/no-unknown-property: 2
-  react/prop-types: 0
+  react/prop-types: 1
   react/react-in-jsx-scope: 2
   react/require-extension: [1, { extensions: [.js, .jsx] }]
   react/self-closing-comp: 2

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -40,7 +40,7 @@ rules:
   react/no-did-update-set-state: 0
   react/no-multi-comp: 2
   react/no-unknown-property: 2
-  react/prop-types: 1
+  react/prop-types: 0
   react/react-in-jsx-scope: 2
   react/require-extension: [1, { extensions: [.js, .jsx] }]
   react/self-closing-comp: 2

--- a/client/app/stores/commentsStore.js
+++ b/client/app/stores/commentsStore.js
@@ -1,4 +1,6 @@
+// react/prop-types rule is ignored because of this issue: https://github.com/yannickcr/eslint-plugin-react/issues/9
 /* eslint react/prop-types: 0 */
+
 import { compose, createStore, applyMiddleware, combineReducers } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import loggerMiddleware from '../middlewares/loggerMiddleware';

--- a/client/app/stores/commentsStore.js
+++ b/client/app/stores/commentsStore.js
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import { compose, createStore, applyMiddleware, combineReducers } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import loggerMiddleware from '../middlewares/loggerMiddleware';
@@ -5,10 +6,11 @@ import reducers from '../reducers';
 import { initalStates } from '../reducers';
 
 export default props => {
+  const initialComments = props;
   const { $$commentsState } = initalStates;
   const initialState = {
     $$commentsStore: $$commentsState.merge({
-      $$comments: props,
+      $$comments: initialComments,
     }),
   };
 


### PR DESCRIPTION
@justin808, @robwise, @alexfedoseev  
I was able to fix the failing Travis CI build with setting Travis to install package `g++-4.9`.

However, I fixed the failing Codeship build by setting `react/prop-types: 0` within `.eslintrc`. 

This was the build fail issue:

<img width="1214" alt="1__dylan_dylans-macbook-pro____react-webpack-rails-tutorial_client__zsh_" src="https://cloud.githubusercontent.com/assets/8039859/11544976/d6542e3e-98e8-11e5-9037-3c3e6bee8450.png">

And referenced here in the issues for `eslint-plugin-react`: 
https://github.com/yannickcr/eslint-plugin-react/issues/9

I am sure you will not want to have this rule continually ignored; therefore, someone will need to address the issue in the code?

Thanks,
Dylan