### PR TITLE
Update package eslint-plugin-react to fix bug

### DIFF
--- a/client/app/bundles/Comments/store/commentsStore.js
+++ b/client/app/bundles/Comments/store/commentsStore.js
@@ -1,6 +1,3 @@
-// react/prop-types rule is ignored because of this issue: https://github.com/yannickcr/eslint-plugin-react/issues/9
-/* eslint react/prop-types: 0 */
-
 import { compose, createStore, applyMiddleware, combineReducers } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import loggerMiddleware from 'lib/middlewares/loggerMiddleware';

--- a/client/package.json
+++ b/client/package.json
@@ -73,7 +73,7 @@
     "css-loader": "^0.23.0",
     "eslint": "^1.10.1",
     "eslint-config-airbnb": "1.0.0",
-    "eslint-plugin-react": "^3.10.0",
+    "eslint-plugin-react": "^3.11.3",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",
     "express": "^4.13.3",
     "file-loader": "^0.8.4",


### PR DESCRIPTION
The package `eslint-plugin-react` was updated to fix this issue: https://github.com/yannickcr/eslint-plugin-react/issues/345#event-483515053

So now we can re-enable the eslint rule that was crashing our `commentStore`. (see #168 and #166).