### PR TITLE
Update Layout to extend BaseComponent. 

### DIFF
--- a/client/app/bundles/comments/layout/Layout.jsx
+++ b/client/app/bundles/comments/layout/Layout.jsx
@@ -1,9 +1,10 @@
 import React, { PropTypes } from 'react';
 import { IndexLink, Link } from 'react-router';
+import BaseComponent from 'libs/components/BaseComponent';
 
 import './Layout.scss';
 
-export default class Layout extends React.Component {
+export default class Layout extends BaseComponent {
 
   static propTypes = {
     children: PropTypes.object.isRequired,


### PR DESCRIPTION
`Layout.jsx` should extend `BaseComponent` both to take advantage of the `PureRenderMixin` and to maintain consistency with the other components used in the example.

Resolves issue shakacode/react-webpack-rails-tutorial#211

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/214)
<!-- Reviewable:end -->
