### PR TITLE
Fix Procfiles to use new process names

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -7,14 +7,13 @@
 rails: REACT_ON_RAILS_ENV=HOT rails s
 
 # Run the hot reload server for client development
-rails-assets: sh -c 'rm app/assets/webpack/* || true && HOT_RAILS_PORT=3500 npm run build:dev:client'
+hot-assets: sh -c 'rm app/assets/webpack/* || true && HOT_RAILS_PORT=3500 npm run hot-assets'
 
-# Keep the JS fresh for server rendering. Remove if not server rendering
-rails-server-assets: sh -c 'npm run build:dev:server'
+# Render static client assets
+rails-static-client-assets: sh -c 'npm run build:dev:client'
 
-# If you don't keep this process going, you will rebuild the assets per spec run. This is configured
-# in rails_helper.rb.
-rails-test: sh -c 'npm run build:test:client'
+# Render static client assets. Remove if not server rendering
+rails-static-server-assets: sh -c 'npm run build:dev:server'
 
 # Run an express server if you want to mock out your endpoints. No Rails involved!
 # Disable this if you are not using it.

--- a/Procfile.spec
+++ b/Procfile.spec
@@ -1,4 +1,9 @@
 # For keeping webpack bundles up-to-date during a testing workflow.
 # If you don't keep this process going, you will rebuild the assets per spec run. This is configured
 # in rails_helper.rb.
-rails-test: sh -c 'npm run build:test:client'
+
+# Build client assets, watching for changes.
+rails-client-assets: sh -c 'npm run build:dev:client'
+
+# Build server assets, watching for changes. Remove if not server rendering.
+rails-server-assets: sh -c 'npm run build:dev:server'

--- a/Procfile.static
+++ b/Procfile.static
@@ -1,4 +1,4 @@
-# Run Rails without hot reloading (static assets)
+# Run Rails without hot reloading (static assets).
 rails: rails s
 
 # Build client assets, watching for changes.

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "build:clean": "rm app/assets/webpack/*",
     "build:production:client": "(cd client && npm run build:production:client --silent)",
     "build:production:server": "(cd client && npm run build:production:server --silent)",
-    "build:dev:client": "(cd client && npm run build:dev:client --silent)",
     "build:client": "(cd client && npm run build:client --silent",
-    "build:dev:server": "(cd client && npm run build:dev:server --silent)",
     "build:server": "(cd client && npm run build:server --silent)",
+    "build:dev:client": "(cd client && npm run build:dev:client --silent)",
+    "build:dev:server": "(cd client && npm run build:dev:server --silent)",
     "hot-assets": "(cd client && npm run hot-assets)",
     "start": "(cd client && npm run start --silent)"
   },


### PR DESCRIPTION
Basically we just don't need the special `build:test:client` script anymore, and you can just use `Procfile.static` to keep your static assets up to date while running your tests.

Also changed the ordering of the scripts so that the client and server versions of the same type of script are next to each other.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/216)
<!-- Reviewable:end -->
