### PR TITLE
Minify js in production.

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -13,8 +13,8 @@ namespace :assets do
 
   desc "Compile assets with webpack"
   task :webpack do
-    sh "cd client && npm run build:client"
-    sh "cd client && npm run build:server"
+    sh "cd client && npm run build:production:client"
+    sh "cd client && npm run build:production:server"
     sh "mkdir -p public/assets"
 
     # Critical to manually copy non js/css assets to public/assets as we don't want to fingerprint them


### PR DESCRIPTION
The rake asset compilation task will now run the production-specific npm build scripts, which employ the `UglifyJsPlugin` plugin.

There may be reasons I'm not aware of to *not* do this, but this is what I would assume would happen for a production build, which is generally what you're targeting when running asset precompilation.

The numbers below just approximately sum vendor and app bundles.

current `bin/rake assets:precompile` (total approx 6.1 MB)

<img width="867" alt="precompile-current" src="https://cloud.githubusercontent.com/assets/816444/13132297/7e62102e-d5bf-11e5-8ccf-21e871dbc0c5.png">

explicitly running npm prod builds in `bin/rake assets:precompile` (total approx 2.3 MB)

<img width="878" alt="precompile-current-prod" src="https://cloud.githubusercontent.com/assets/816444/13132302/85e2580e-d5bf-11e5-9078-de3a0719693c.png">


explicitly running npm prod builds in `bin/rake assets:precompile` AND adding minification plugin (total approx 600 KB)

<img width="875" alt="precompile-witih-min" src="https://cloud.githubusercontent.com/assets/816444/13132307/8b5ae896-d5bf-11e5-8b8b-3cbe52c86e8f.png">

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/234)
<!-- Reviewable:end -->
