### PR TITLE
Remove babel-eslint and eslint-config-airbnb

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -85,14 +85,12 @@
     "webpack": "^1.12.14"
   },
   "devDependencies": {
-    "babel-eslint": "^5.0.0",
     "babel-plugin-react-transform": "^2.0.2",
     "body-parser": "^1.15.0",
     "chai": "^3.5.0",
     "chai-immutable": "^1.5.3",
     "eslint": "^2.3.0",
     "eslint-config-shakacode": "^3.0.0",
-    "eslint-config-airbnb": "^6.0.2",
     "eslint-plugin-react": "^4.2.0",
     "express": "^4.13.4",
     "jade": "^1.11.0",


### PR DESCRIPTION
Those are dependencies of eslint-config-shakacode, so including them
creates a chance of a version conflict.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/243)
<!-- Reviewable:end -->
