### PR TITLE
Remove unnecessary erb suffix

### DIFF
--- a/app/assets/stylesheets/application_static.scss
+++ b/app/assets/stylesheets/application_static.scss
@@ -3,10 +3,8 @@
 
 // Super important: This file is loaded even for hot loading only, so we need to be sure
 // that we don't reference the static generated CSS files.
-<% unless ENV["REACT_ON_RAILS_ENV"] == "HOT" %>
-  @import 'vendor-bundle';
-  @import 'app-bundle';
-<% end %>
+@import 'vendor-bundle';
+@import 'app-bundle';
 
 // Non-webpack assets
 @import 'application_non_webpack';


### PR DESCRIPTION
This logic is handled by /config/initializers/assets.rb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/255)
<!-- Reviewable:end -->
