### PR TITLE
Update README with instructions for installing qmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ See package.json and Gemfile for versions
 1. Check that you have Ruby 2.2.4 or greater
 1. Check that you're using the right version of node. Run `nvm list` to check. Use 5.5 or greater.
 1. Check that you have Postgres installed. Run `which postgres` to check. Use 9.4 or greater.
+1. Check that you have `qmake` installed. Run `which qmake` to check. If missing, follow these instructions: [Installing Qt and compiling capybara-webkit](https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit)
 1. `bundle install`
 1. `npm install`
 1. `rake db:setup`


### PR DESCRIPTION
On a fresh install on OSX, `capybara-webkit` will fail to build.

```sh
Installing capybara-webkit 1.8.0 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
[..]
Command 'qmake' not available
```

`capybara-webkit` is required only by the Gemfile's test group, so one option is to simply exclude that test group when installing.

I think a better option is to provide instructions for how to get `qmake` installed. The actual commands required on OSX are:

```sh
brew tap homebrew/versions
brew install qt55
brew link --force qt55
```

But since those might change, and vary for other operating systems, I recommend linking to the `capybara-webkit` install docs directly in the README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/262)
<!-- Reviewable:end -->
