### PR TITLE
Fix server-side rendering for non-root URLs

### DIFF
--- a/client/app/bundles/comments/startup/ServerRouterApp.jsx
+++ b/client/app/bundles/comments/startup/ServerRouterApp.jsx
@@ -11,7 +11,7 @@ export default (props, railsContext) => {
   let error;
   let redirectLocation;
   let routeProps;
-  const location = { railsContext };
+  const location = railsContext.href;
 
   // See https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md
   match({ routes, location }, (_error, _redirectLocation, _routeProps) => {


### PR DESCRIPTION
`match`es first argument is an object containing the routes and the location as an URL,
as described in https://github.com/reactjs/react-router/blob/master/docs/guides/ServerRendering.md .
This fixes the provided `location`-variable, so that it contains the full URL instead of an object.

This only affected server-side-rendering, which would always render the Component linked
to the `/`-URL with react-router.
If JS was activated client-side, the Client would rewrite the DOM (albeit while logging an error), so that the user would see the correct page in that case.

Maybe you should consider integrating server-side rendering into your example so this gets tested in the future :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/276)
<!-- Reviewable:end -->
