### PR TITLE
update heroku documentation

### DIFF
--- a/Procfile.hot
+++ b/Procfile.hot
@@ -1,6 +1,6 @@
 # Basic procfile for dev work.
 # Runs all processes. Development is faster if you pick one of the other Procfiles if you don't need
-# some of the processes: Procfile.rails or Procfile.express
+# some of the processes: Procfile.hot or Procfile.express
 
 # Development rails requires both rails and rails-assets
 # (and rails-server-assets if server rendering)

--- a/docs/heroku.md
+++ b/docs/heroku.md
@@ -9,7 +9,7 @@ buildpack:
 heroku config:add BUILDPACK_URL=https://github.com/ddollar/heroku-buildpack-multi.git
 ```
 
-This runs the two buildpacks in the `.buildpacks` directory.
+This runs the three buildpacks in the `.buildpacks` file.
 
 Also make sure you are running the latest heroku stack, cedar-14, to avoid running
 into the [following issue](https://github.com/sass/node-sass/issues/467#issuecomment-61729195).


### PR DESCRIPTION
Looks like currently there are three buildpacks being run from the .buildpacks file rather than from a directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/284)
<!-- Reviewable:end -->
