### PR TITLE
Enable serving static assets in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,6 +11,9 @@ Rails.application.configure do
 
   # Show full error reports.
   config.consider_all_requests_local = true
+  
+  # Enable serving static assets
+  config.public_file_server.enable
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join("tmp/caching-dev.txt").exist?


### PR DESCRIPTION
I noticed that I wasn't able to use `image_tag` within a view. Just needed to activate static asset serving in development mode.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/302)

<!-- Reviewable:end -->
