### PR TITLE
[Possible No-op] Adjust Procfiles for compatibility with both foreman and forego

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -7,13 +7,13 @@
 rails: REACT_ON_RAILS_ENV=HOT rails s -b 0.0.0.0
 
 # Run the hot reload server for client development
-hot-assets: sh -c 'rm app/assets/webpack/* || true && HOT_RAILS_PORT=3500 npm run hot-assets'
+hot_assets: sh -c 'rm app/assets/webpack/* || true && HOT_RAILS_PORT=3500 npm run hot-assets'
 
 # Render static client assets
-rails-static-client-assets: sh -c 'npm run build:dev:client'
+rails_static_client_assets: sh -c 'npm run build:dev:client'
 
 # Render static client assets. Remove if not server rendering
-rails-static-server-assets: sh -c 'npm run build:dev:server'
+rails_static_server_assets: sh -c 'npm run build:dev:server'
 
 # Run an express server if you want to mock out your endpoints. No Rails involved!
 # Disable this if you are not using it.

--- a/Procfile.hot
+++ b/Procfile.hot
@@ -6,7 +6,7 @@
 rails: REACT_ON_RAILS_ENV=HOT rails s -b 0.0.0.0
 
 # Run the hot reload server for client development
-hot-assets: sh -c 'rm app/assets/webpack/* || true && HOT_RAILS_PORT=3500 npm run hot-assets'
+hot_assets: sh -c 'rm app/assets/webpack/* || true && HOT_RAILS_PORT=3500 npm run hot-assets'
 
 # Keep the JS fresh for server rendering. Remove if not server rendering
-rails-server-assets: sh -c 'npm run build:dev:server'
+rails_server_assets: sh -c 'npm run build:dev:server'

--- a/Procfile.spec
+++ b/Procfile.spec
@@ -3,7 +3,7 @@
 # in rails_helper.rb.
 
 # Build client assets, watching for changes.
-rails-client-assets: sh -c 'npm run build:dev:client'
+rails_client_assets: sh -c 'npm run build:dev:client'
 
 # Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: sh -c 'npm run build:dev:server'
+rails_server_assets: sh -c 'npm run build:dev:server'

--- a/Procfile.static
+++ b/Procfile.static
@@ -2,7 +2,7 @@
 rails: REACT_ON_RAILS_ENV= rails s -b 0.0.0.0
 
 # Build client assets, watching for changes.
-rails-client-assets: rm app/assets/webpack/* || true && npm run build:dev:client
+rails_client_assets: rm app/assets/webpack/* || true && npm run build:dev:client
 
 # Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: npm run build:dev:server
+rails_server_assets: npm run build:dev:server

--- a/Procfile.static.trace
+++ b/Procfile.static.trace
@@ -2,7 +2,7 @@
 rails: TRACE_REACT_ON_RAILS=TRUE rails s -b 0.0.0.0
 
 # Build client assets, watching for changes.
-rails-client-assets: npm run build:dev:client
+rails_client_assets: npm run build:dev:client
 
 # Build server assets, watching for changes. Remove if not server rendering.
-rails-server-assets: npm run build:dev:server
+rails_server_assets: npm run build:dev:server


### PR DESCRIPTION
First off, thanks for all your work on this project :).

forego doesn't allow - in the name of processes. This allows both
foreman and forego to work with these procfiles.

Link to regex in forego looks like it should work for dashes:
https://github.com/ddollar/forego/blob/master/procfile.go#L12. But
testing on my OSX dev machine using forego 0.16.1 (latest) shows it
fail to parse any of them beyond the `rails` entry. I also tried
rearranging order of entries in Procfiles, with same issue.

I'll take a look in forego to see if it should be fixed upstream, but
wanted to log this here in case anyone else get stumped for a bit trying
to debug this :).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/310)
<!-- Reviewable:end -->
