### PR TITLE
Remove mini_racer as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,10 +39,6 @@ gem "rails-html-sanitizer"
 
 gem "react_on_rails", "~> 6.1"
 
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-# mini_racer is probably faster than therubyracer
-gem "mini_racer"
-
 gem "autoprefixer-rails"
 
 gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,6 @@ GEM
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (5.3.332.38.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -132,8 +131,6 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    mini_racer (0.1.7)
-      libv8 (~> 5.3)
     minitest (5.9.1)
     multi_json (1.12.1)
     nio4r (1.2.1)
@@ -316,7 +313,6 @@ DEPENDENCIES
   jbuilder
   launchy
   listen
-  mini_racer
   pg
   poltergeist
   pry


### PR DESCRIPTION
Since we depend on nodejs properly, we can just let execjs use node instead of pulling in the huge libv8 dependency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/350)
<!-- Reviewable:end -->
