### PR TITLE
Update BaseComponent.jsx

### DIFF
--- a/client/app/libs/components/BaseComponent.jsx
+++ b/client/app/libs/components/BaseComponent.jsx
@@ -1,8 +1,4 @@
 import React from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 
-export default class BaseComponent extends React.Component {
-  shouldComponentUpdate(theArgs) {
-    return PureRenderMixin.shouldComponentUpdate.apply(this, ...theArgs);
-  }
-}
+export default class BaseComponent extends React.PureComponent {
+};

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -4619,11 +4619,6 @@
       "from": "react-addons-css-transition-group@latest",
       "resolved": "https://registry.npmjs.org/react-addons-css-transition-group/-/react-addons-css-transition-group-15.4.1.tgz"
     },
-    "react-addons-pure-render-mixin": {
-      "version": "15.4.1",
-      "from": "react-addons-pure-render-mixin@>=15.4.1 <16.0.0",
-      "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-15.4.1.tgz"
-    },
     "react-addons-test-utils": {
       "version": "15.4.1",
       "from": "react-addons-test-utils@>=15.4.1 <16.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -71,7 +71,6 @@
     "postcss-loader": "^1.1.1",
     "react": "^15.4.1",
     "react-addons-css-transition-group": "^15.4.1",
-    "react-addons-pure-render-mixin": "^15.4.1",
     "react-bootstrap": "^0.30.7",
     "react-dom": "^15.4.1",
     "react-on-rails": "^6.2.1",

--- a/client/webpack.client.base.config.js
+++ b/client/webpack.client.base.config.js
@@ -31,7 +31,6 @@ module.exports = {
       'immutable',
       'lodash',
       'marked',
-      'react-addons-pure-render-mixin',
       'react-bootstrap',
       'react-dom',
       'react-redux',


### PR DESCRIPTION
Hey, I'm proposing a change in the BaseComponent as it seems to be using the `PureRenderMixin` mixin. The react docs states that we should consider using React.PureComponent instead, which essentially does the same shallow compare.
<img width="675" alt="screen shot 2016-12-18 at 1 26 17 pm" src="https://cloud.githubusercontent.com/assets/15992549/21296686/62287cca-c526-11e6-96fb-5581d1741c5c.png">
<img width="676" alt="screen shot 2016-12-18 at 1 24 28 pm" src="https://cloud.githubusercontent.com/assets/15992549/21296687/63b081a0-c526-11e6-826e-2ae9922d375b.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/351)
<!-- Reviewable:end -->
