### PR TITLE
Change configuration for ActionCable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Your support keeps this project going!
 
 (Want to become a contributor? [Contact us](mailto:contact@shakacode.com) for an Slack team invite! Also, see ["easy" issues](https://github.com/shakacode/react_on_rails/labels/easy) and [issues for the full tutorial](https://github.com/shakacode/react-webpack-rails-tutorial/issues?q=is%3Aissue+is%3Aopen+label%3Aeasy).)
 
+# React on Rails Pro!
+Justin is currently working with a couple contributors on some new private examples that incorporate ShakaCode's best practices for industrial strength apps using React on Rails. If you're interested in getting access to these and/or contributing, [email justin@shakacode.com](mailto:justin@shakacode.com). Technologies will include Webpack v2, Yarn, CSS Modules, Bootstrap v4, Redux-Saga, Normalizr, Reselect, etc.
+
 # ShakaCode Community
 Please [Subscribe](https://app.mailerlite.com/webforms/landing/l1d9x5) to keep in touch with Justin Gordon and [ShakaCode](http://www.shakacode.com/). I intend to send a monthly summary including announcements of new releases of bootstrap-loader and React on Rails and of our latest [blog articles](https://blog.shakacode.com) and tutorials. Subscribers will also have access to **exclusive content**, including tips and examples.
 
@@ -38,8 +41,8 @@ For more testimonials, see [Live Projects](https://github.com/shakacode/react_on
 
 ## NEWS
 
-* Action Cable was recently added in [PR #355](https://github.com/shakacode/react-webpack-rails-tutorial/pull/355).
-* We made react-native client: [shakacode/reactrails-react-native-client](https://github.com/shakacode/reactrails-react-native-client/)
+* Action Cable was recently added in [PR #355](https://github.com/shakacode/react-webpack-rails-tutorial/pull/355). See [PR#360](https://github.com/shakacode/react-webpack-rails-tutorial/pull/360) for additional steps to make this work on Heroku. Note, you need to be running redis. We installed the free Heroku redis add-on.
+* We made a react-native client: [shakacode/reactrails-react-native-client](https://github.com/shakacode/reactrails-react-native-client/). If you want to hack on this with us, [email justin@shakacode.com](mailto:justin@shakacode.com).
 * We have [some other open PRs](https://github.com/shakacode/react-webpack-rails-tutorial/pulls) of things we may soon be incorporating, including localization and action cable! Stay tuned! If you have opinions of what should or should not get merged, get in touch with [justin@shakacode.com](mailto:justin@shakacode.com).
 
 This tutorial app demonstrates advanced functionality beyond what's provided by the React on Rails generators, mostly in the area of Webpack and React usage. Due to the architecture of placing all client side assets in the `/client` directory, React on Rails supports just about anything that Webpack and JavaScript can do, such as:

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,7 +1,7 @@
 # Action Cable uses Redis by default to administer connections, channels, and sending/receiving messages over the WebSocket.
 production:
   adapter: redis
-  url: <%= ENV["REDISCLOUD_URL"] %>
+  url: <%= ENV["REDIS_URL"] %>
 
 development:
   adapter: redis

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,9 +38,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Action Cable endpoint configuration
-  # config.action_cable.url = 'wss://example.com/cable'
-
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
@@ -85,4 +82,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Action Cable endpoint configuration
+
+  config.action_cable.url = "wss://#{ENV['PRODUCTION_HOST']}/cable"
+  config.action_cable.allowed_request_origins = ["https://#{ENV['PRODUCTION_HOST']}"]
 end


### PR DESCRIPTION
See article
https://blog.heroku.com/real_time_rails_implementing_websockets_in_rails_5_with_action_cable

This fix requires this command to be run:
```
heroku config:set PRODUCTION_HOST=www.reactrails.com  --app react-webpack-rails-tutorial
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/360)
<!-- Reviewable:end -->
