### PR TITLE
Removed and replaced no longer available repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Save a change to a JSX file and see it update immediately in the browser! Note, 
       ```
       heroku buildpacks:set heroku/ruby --app your-app
       heroku buildpacks:add --index 1 heroku/nodejs --app your-app
-      heroku buildpacks:set --index 3 https://github.com/tempoautomation/heroku-buildpack-sourceversion.git --app your-app
+      heroku buildpacks:set --index 3 https://github.com/sreid/heroku-buildpack-sourceversion.git --app your-app
       ```
 + **Development Mode**: Two flavors: Hot reloading assets (JavaScript & CSS) and Static loading.
    + **Hot Loading**: We modify the URL in [application.html.erb](app/views/layouts/application.html.erb) based on whether or not we're in production mode using the helpers `env_stylesheet_link_tag` and `env_javascript_include_tag`. *Development mode* uses the Webpack Dev server running on port 3500. Other modes (production/test) use precompiled files. See `Procfile.hot`. `Procfile.dev` also starts this mode. Note, *you don't have to refresh a Rails web page to view changes to JavaScript or CSS*.


### PR DESCRIPTION
The old repo doesn't exist anymore, so I think replacing it with the original source makes sense here. Worked fine with my heroku deployment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/400)
<!-- Reviewable:end -->
