### PR TITLE
README: Use HTTPS URL instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ See package.json and Gemfile for versions
 
 ## Basic Demo Setup
 1. Be sure that you have Node installed! We suggest [nvm](https://github.com/creationix/nvm), with node version `v6.0` or above. See this article [Updating and using nvm](http://forum.shakacode.com/t/updating-and-using-nvm/293).
-1. `git clone git@github.com:shakacode/react-webpack-rails-tutorial.git`
+1. `git clone https://github.com/shakacode/react-webpack-rails-tutorial.git`
 1. `cd react-webpack-rails-tutorial`
 1. Check that you have Ruby 2.3.0 or greater
 1. Check that you're using the right version of node. Run `nvm list` to check. Use 5.5 or greater.


### PR DESCRIPTION
Using HTTPS is the [recommended way by Github](https://help.github.com/articles/which-remote-url-should-i-use/) when cloning repos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/418)
<!-- Reviewable:end -->
