### PR TITLE
Fix webpack asset bundling for tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,7 +35,7 @@
     "build:dev:client": "NODE_ENV=development webpack -w --config webpack.client.rails.build.config.js",
     "build:dev:server": "NODE_ENV=development webpack -w --config webpack.server.rails.build.config.js",
     "build:server": "webpack --config webpack.server.rails.build.config.js",
-    "build:test": "rm -rf ../public/webpack/test && NODE_ENV=test yarn run build:client && NODE_ENV=test yarn run build:server",
+    "build:test": "rm -rf ../public/webpack-test && NODE_ENV=test yarn run build:client && NODE_ENV=test yarn run build:server",
     "build:production": "rm -rf ../public/webpack/production && NODE_ENV=production yarn run build:production:client && yarn run build:production:server",
     "hot-assets": "NODE_ENV=development babel-node server-rails-hot.js",
     "lint": "eslint --ext .js,.jsx ."

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "postinstall": "cd client && yarn install",
-    "test": "rspec && yarn run test:client && yarn run lint",
+    "test": "(cd client && yarn run build:test) && rspec && yarn run test:client && yarn run lint",
     "test:client": "(cd client && yarn run --silent test)",
     "lint": "(cd client && yarn run --silent lint)",
     "build:clean": "rm app/assets/webpack/*",


### PR DESCRIPTION
@justin808 I am using this to try and troubleshoot the CI problems.  They seem to be caused by asset compilation failures, and I have found a couple different places this is failing prior to test runs running locally.  

The package.json changes in this PR fixes one of them.  When running `(cd client && yarn run build:test)`, webpack runs and appears to succeed, but actually the bundles are not updated because the `rm` statement that is supposed to delete the contents of `public/webpack-test` had a syntax error and doesn't do its thing.

There are other places test run asset compilation isn't working, we'll see if this passes CI and I will take it from there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/433)
<!-- Reviewable:end -->
