### PR TITLE
updated nokogori gem to enable deployment to heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.1)
     minitest (5.15.0)
     net-imap (0.3.2)
       date
@@ -160,8 +160,8 @@ GEM
     net-smtp (0.3.2)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.10)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.1.1.0)
@@ -187,7 +187,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
-    racc (1.6.0)
+    racc (1.6.2)
     rack (2.2.3)
     rack-proxy (0.7.2)
       rack
@@ -413,4 +413,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.5
+   2.3.26


### PR DESCRIPTION
Deployment to heroku was failing due to nokogori dependency issue:

```
remote: -----> Using Ruby version: ruby-3.1.2
remote:        Purging Cache. Changing stack from cedar-14 to heroku-22
remote: -----> Installing dependencies using bundler 2.3.25
remote:        Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
remote:        Fetching gem metadata from https://rubygems.org/.........
remote:        nokogiri-1.12.5-x86_64-linux requires ruby version < 3.1.dev, >= 2.5, which is
remote:        incompatible with the current version, 3.1.2
remote:        Bundler Output: Fetching gem metadata from https://rubygems.org/.........
remote:        nokogiri-1.12.5-x86_64-linux requires ruby version < 3.1.dev, >= 2.5, which is
remote:        incompatible with the current version, 3.1.2
```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/509)
<!-- Reviewable:end -->
