### PR TITLE
Ignore warning for react-dom/client not found

### DIFF
--- a/config/webpack/commonWebpackConfig.js
+++ b/config/webpack/commonWebpackConfig.js
@@ -18,6 +18,10 @@ const sassLoaderConfig = {
   },
 };
 
+const ignoreWarningsConfig = {
+  ignoreWarnings: [/Module not found: Error: Can't resolve 'react-dom\/client'/],
+};
+
 const scssConfigIndex = baseClientWebpackConfig.module.rules.findIndex((config) =>
   '.scss'.match(config.test),
 );
@@ -25,6 +29,6 @@ const scssConfigIndex = baseClientWebpackConfig.module.rules.findIndex((config) 
 baseClientWebpackConfig.module.rules[scssConfigIndex].use.push(sassLoaderConfig);
 
 // Copy the object using merge b/c the baseClientWebpackConfig and commonOptions are mutable globals
-const commonWebpackConfig = () => merge({}, baseClientWebpackConfig, commonOptions);
+const commonWebpackConfig = () => merge({}, baseClientWebpackConfig, commonOptions, ignoreWarningsConfig);
 
 module.exports = commonWebpackConfig;

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -1,4 +1,4 @@
-const { env, webpackConfig } = require('shakapacker');
+const { env, webpackConfig, merge } = require('shakapacker');
 const { existsSync } = require('fs');
 const { resolve } = require('path');
 
@@ -12,4 +12,6 @@ const envSpecificConfig = () => {
   }
 };
 
-module.exports = envSpecificConfig();
+module.exports = merge(envSpecificConfig(), {
+  ignoreWarnings: [/Module not found: Error: Can't resolve 'react-dom\/client'/],
+});

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -1,4 +1,4 @@
-const { env, webpackConfig, merge } = require('shakapacker');
+const { env, webpackConfig } = require('shakapacker');
 const { existsSync } = require('fs');
 const { resolve } = require('path');
 
@@ -12,6 +12,4 @@ const envSpecificConfig = () => {
   }
 };
 
-module.exports = merge(envSpecificConfig(), {
-  ignoreWarnings: [/Module not found: Error: Can't resolve 'react-dom\/client'/],
-});
+module.exports = envSpecificConfig();


### PR DESCRIPTION
As per [this PR on React_on_Rails](https://github.com/shakacode/react_on_rails/pull/1460/), we can safely ignore warning related to requiring `react-dom/client` in React <18.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/519)
<!-- Reviewable:end -->
