### PR TITLE
Update the link to ROR doctrine

### DIFF
--- a/app/views/pages/_header.html.erb
+++ b/app/views/pages/_header.html.erb
@@ -20,7 +20,7 @@
     Read <%= link_to "Documentation for React on Rails",
                 "https://shakacode.gitbooks.io/react-on-rails/content/" %> and
     <%= link_to "The React on Rails Doctrine",
-                "http://www.shakacode.com/2016/01/27/the-react-on-rails-doctrine.html" %>.
+                "https://www.shakacode.com/blog/the-react-on-rails-doctrine" %>.
   </li>
   <li>
     See our React Native Client:


### PR DESCRIPTION
The link to "The React on Rails Doctrine" article was the old one. It is updated to the new link at https://www.shakacode.com/blog/the-react-on-rails-doctrine/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/531)
<!-- Reviewable:end -->
