### PR TITLE
Upgrade redis to v4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "coffee-rails"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder"
-gem "redis", "3.3.3"
+gem "redis", "~> 4.0"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
       rails (>= 5.2)
       rainbow (~> 3.0)
     redcarpet (3.6.0)
-    redis (3.3.3)
+    redis (4.8.1)
     regexp_parser (2.8.1)
     reline (0.3.8)
       io-console (~> 0.5)
@@ -454,7 +454,7 @@ DEPENDENCIES
   rainbow
   react_on_rails (= 13.2.0)
   redcarpet
-  redis (= 3.3.3)
+  redis (~> 4.0)
   rspec-rails (~> 6.0.0)
   rubocop (= 1.24.1)
   rubocop-performance (~> 1.13)


### PR DESCRIPTION
After upgrading Rails to v7.1, it is necessary to upgrade Redis to v4+.

This PR fixes the issue of submitting comments and broadcasting them to all active sessions. It doesn't resolve the errors related to deleting comments in the Classic Rails tab.

---
Closes #558 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/561)
<!-- Reviewable:end -->
