### PR TITLE
WIP - Improve docker images for faster build and deploy

### DIFF
--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -36,4 +36,4 @@ RUN rails assets:precompile
 COPY .controlplane/entrypoint.sh ./
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-CMD ["rails", "s"]
+CMD ["rails", "server"]

--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -1,4 +1,26 @@
-FROM ahangarha/rwrt-base:latest
+FROM ruby:3.1.2
+
+RUN apt-get update
+
+# install node and yarn
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
+RUN apt-get install -y nodejs
+RUN npm install -g yarn
+
+WORKDIR /app
+
+# install ruby gems
+COPY Gemfile* ./
+
+RUN bundle config set without 'development test' && \
+    bundle config set with 'staging production' && \
+    bundle install --jobs=3 --retry=3
+
+# install node packages
+COPY package.json yarn.lock ./
+RUN yarn install
+
+COPY . ./
 
 ENV RAILS_ENV=production
 ENV NODE_ENV=production
@@ -7,11 +29,11 @@ ENV NODE_ENV=production
 ENV SECRET_KEY_BASE=NOT_USED_NON_BLANK
 
 RUN yarn res:build
-RUN bin/rails react_on_rails:locale
-RUN bin/rails assets:precompile
+RUN rails react_on_rails:locale
+RUN rails assets:precompile
 
 # add entrypoint
 COPY .controlplane/entrypoint.sh ./
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-CMD ["./bin/rails", "s"]
+CMD ["rails", "s"]

--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -1,26 +1,4 @@
-FROM ruby:3.1.2
-
-RUN apt-get update
-
-# install node and yarn
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
-RUN apt-get install -y nodejs
-RUN npm install -g yarn
-
-WORKDIR /app
-
-# install ruby gems
-COPY Gemfile* ./
-
-RUN bundle config set without 'development test' && \
-    bundle config set with 'staging production' && \
-    bundle install --jobs=3 --retry=3
-
-# install node packages
-COPY package.json yarn.lock ./
-RUN yarn install
-
-COPY . ./
+FROM ahangarha/rwrt-base:latest
 
 ENV RAILS_ENV=production
 ENV NODE_ENV=production
@@ -29,11 +7,11 @@ ENV NODE_ENV=production
 ENV SECRET_KEY_BASE=NOT_USED_NON_BLANK
 
 RUN yarn res:build
-RUN rails react_on_rails:locale
-RUN rails assets:precompile
+RUN bin/rails react_on_rails:locale
+RUN bin/rails assets:precompile
 
 # add entrypoint
 COPY .controlplane/entrypoint.sh ./
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-CMD ["rails", "s"]
+CMD ["./bin/rails", "s"]

--- a/.controlplane/Dockerfile_from_base
+++ b/.controlplane/Dockerfile_from_base
@@ -1,3 +1,7 @@
+# This Dockerfile should be used for a faster image build on top of the base
+# image from Docker hub (shakacode/rwrt-base:latest). To this end, uncomment
+# the line for the custom dockerfile in the controlplane.yml file.
+
 FROM ahangarha/rwrt-base:latest
 
 ENV RAILS_ENV=production

--- a/.controlplane/Dockerfile_from_base
+++ b/.controlplane/Dockerfile_from_base
@@ -2,7 +2,7 @@
 # image from Docker hub (shakacode/rwrt-base:latest). To this end, uncomment
 # the line for the custom dockerfile in the controlplane.yml file.
 
-FROM ahangarha/rwrt-base:latest
+FROM shakacode/rwrt-base:latest
 
 ENV RAILS_ENV=production
 ENV NODE_ENV=production

--- a/.controlplane/Dockerfile_from_base
+++ b/.controlplane/Dockerfile_from_base
@@ -1,0 +1,16 @@
+FROM ahangarha/rwrt-base:latest
+
+ENV RAILS_ENV=production
+ENV NODE_ENV=production
+
+# compiling assets requires any value for ENV of SECRET_KEY_BASE
+ENV SECRET_KEY_BASE=NOT_USED_NON_BLANK
+
+RUN bin/rails react_on_rails:locale
+RUN bin/rails assets:precompile
+
+# add entrypoint
+COPY .controlplane/entrypoint.sh ./
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+CMD ["./bin/rails", "s"]

--- a/.controlplane/Dockerfile_from_base
+++ b/.controlplane/Dockerfile_from_base
@@ -6,6 +6,7 @@ ENV NODE_ENV=production
 # compiling assets requires any value for ENV of SECRET_KEY_BASE
 ENV SECRET_KEY_BASE=NOT_USED_NON_BLANK
 
+RUN yarn res:build
 RUN bin/rails react_on_rails:locale
 RUN bin/rails assets:precompile
 

--- a/.controlplane/Dockerfile_from_base
+++ b/.controlplane/Dockerfile_from_base
@@ -13,4 +13,4 @@ RUN bin/rails assets:precompile
 COPY .controlplane/entrypoint.sh ./
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-CMD ["./bin/rails", "s"]
+CMD ["./bin/rails", "server"]

--- a/.controlplane/controlplane.yml
+++ b/.controlplane/controlplane.yml
@@ -22,6 +22,9 @@ aliases:
       - redis
       - postgres
 
+    # To use the base image for a faster build process, uncomment this line:
+    # dockerfile: Dockerfile_from_base
+
 apps:
   react-webpack-rails-tutorial:
     <<: *common

--- a/.controlplane/entrypoint.sh
+++ b/.controlplane/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 # Runs before the main command
 
 wait_for_service()

--- a/.controlplane/entrypoint.sh
+++ b/.controlplane/entrypoint.sh
@@ -18,8 +18,11 @@ echo " -- Waiting for services"
 wait_for_service $(echo $DATABASE_URL | sed -e 's|^.*@||' -e 's|/.*$||')
 wait_for_service $(echo $REDIS_URL | sed -e 's|redis://||' -e 's|/.*$||')
 
-echo " -- Preparing database"
-rails db:prepare
+# If running the rails server then create or migrate existing database
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+  echo " -- Preparing database"
+  ./bin/rails db:prepare
+fi
 
 echo " -- Finishing entrypoint.sh, executing '$@'"
 exec "$@"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,78 @@
-# TODO: Document where used
-# Maybe outdated.
-# Control Plane setup is in the .controlplane directory
-FROM ruby:3.1.2
+# syntax = docker/dockerfile:1
 
-RUN apt-get update
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=3.1.2
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
-RUN apt-get install -y nodejs
-RUN npm install -g yarn
+# Rails app lives here
+WORKDIR /rails
 
-WORKDIR /app
-COPY Gemfile* ./
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development"
 
-RUN bundle install
 
+# Throw-away build stage to reduce size of final image
+FROM base as build
+
+# Install packages needed to build gems and node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
+
+# Install JavaScript dependencies
+# Make sure NODE_VERSION matches the node version in .nvmrc
+ARG NODE_VERSION=18.13.0
+ARG YARN_VERSION=1.22.19
+ENV PATH=/usr/local/node/bin:$PATH
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    npm install -g yarn@$YARN_VERSION && \
+    rm -rf /tmp/node-build-master
+
+# Install application gems
+COPY Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
+    bundle exec bootsnap precompile --gemfile
+
+# Install node modules
 COPY package.json yarn.lock ./
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
-COPY . ./
+# Copy application code
+COPY . .
 
-ENV RAILS_ENV=production
-ENV NODE_ENV=production
+# Precompile bootsnap code for faster boot times
+RUN bundle exec bootsnap precompile app/ lib/
 
-RUN rails react_on_rails:locale && rails assets:precompile
+# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
-CMD ["rails", "s"]
+RUN rails react_on_rails:locale
+RUN rails assets:precompile
+
+# Final stage for app image
+FROM base
+
+# Install packages needed for deployment
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl libvips postgresql-client && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy built artifacts: gems, application
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build /rails /rails
+
+# Run and own only the runtime files as a non-root user for security
+RUN useradd rails --create-home --shell /bin/bash && \
+    chown -R rails:rails db log storage tmp
+USER rails:rails
+
+# Entrypoint prepares the database.
+ENTRYPOINT ["/rails/bin/docker-entrypoint"]
+
+# Start the server by default, this can be overwritten at runtime
+EXPOSE 3000
+CMD ["./bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --from=build /rails /rails
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    chown -R rails:rails db log tmp
 USER rails:rails
 
 # Entrypoint prepares the database.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,7 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
 # Install application gems
 COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
-    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
-    bundle exec bootsnap precompile --gemfile
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
 
 # Install node modules
 COPY package.json yarn.lock ./
@@ -43,9 +42,6 @@ RUN yarn install --frozen-lockfile
 
 # Copy application code
 COPY . .
-
-# Precompile bootsnap code for faster boot times
-RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,6 @@ RUN yarn install --frozen-lockfile
 # Copy application code
 COPY . .
 
-# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails react_on_rails:locale
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-
 # Final stage for app image
 FROM base
 
@@ -58,15 +54,3 @@ RUN apt-get update -qq && \
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /app /app
-
-# Run and own only the runtime files as a non-root user for security
-RUN useradd rails --create-home --shell /bin/bash && \
-    chown -R rails:rails db log tmp
-USER rails:rails
-
-# Entrypoint prepares the database.
-ENTRYPOINT ["/rails/bin/docker-entrypoint"]
-
-# Start the server by default, this can be overwritten at runtime
-EXPOSE 3000
-CMD ["./bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,10 +44,8 @@ RUN yarn install --frozen-lockfile
 COPY . .
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails react_on_rails:locale
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-
-RUN ./bin/rails react_on_rails:locale
-RUN ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,56 +1,27 @@
-# syntax = docker/dockerfile:1
+# TODO: Document where used
+# Maybe outdated.
+# Control Plane setup is in the .controlplane directory
+FROM ruby:3.1.2
 
-# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
-ARG RUBY_VERSION=3.1.2
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
+RUN apt-get update
 
-# Install packages needed to build gems and node modules
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
+RUN apt-get install -y nodejs
+RUN npm install -g yarn
 
-# Install JavaScript dependencies
-# Make sure NODE_VERSION matches the node version in .nvmrc
-ARG NODE_VERSION=18.13.0
-ARG YARN_VERSION=1.22.19
-ENV PATH=/usr/local/node/bin:$PATH
-RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
-    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
-    npm install -g yarn@$YARN_VERSION && \
-    rm -rf /tmp/node-build-master
-
-# Rails app lives here
 WORKDIR /app
+COPY Gemfile* ./
 
-# Set production environment
-ENV RAILS_ENV="production" \
-    BUNDLE_DEPLOYMENT="1" \
-    BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
+RUN bundle install
 
-
-# Throw-away build stage to reduce size of final image
-FROM base as build
-
-# Install application gems
-COPY Gemfile Gemfile.lock ./
-RUN bundle install && \
-    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
-
-# Install node modules
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+RUN yarn install
 
-# Copy application code
-COPY . .
+COPY . ./
 
-# Final stage for app image
-FROM base
+ENV RAILS_ENV=production
+ENV NODE_ENV=production
 
-# Install packages needed for deployment
-RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libvips postgresql-client && \
-    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+RUN rails react_on_rails:locale && rails assets:precompile
 
-# Copy built artifacts: gems, application
-COPY --from=build /usr/local/bundle /usr/local/bundle
-COPY --from=build /app /app
+CMD ["rails", "s"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
     rm -rf /tmp/node-build-master
 
 # Rails app lives here
-WORKDIR /rails
+WORKDIR /app
 
 # Set production environment
 ENV RAILS_ENV="production" \
@@ -57,7 +57,7 @@ RUN apt-get update -qq && \
 
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle
-COPY --from=build /rails /rails
+COPY --from=build /app /app
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ COPY . .
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
-RUN rails react_on_rails:locale
-RUN rails assets:precompile
+RUN ./bin/rails react_on_rails:locale
+RUN ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,6 @@
 ARG RUBY_VERSION=3.1.2
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
 
-# Rails app lives here
-WORKDIR /rails
-
-# Set production environment
-ENV RAILS_ENV="production" \
-    BUNDLE_DEPLOYMENT="1" \
-    BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development"
-
-
-# Throw-away build stage to reduce size of final image
-FROM base as build
-
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
@@ -30,6 +17,19 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
     npm install -g yarn@$YARN_VERSION && \
     rm -rf /tmp/node-build-master
+
+# Rails app lives here
+WORKDIR /rails
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development"
+
+
+# Throw-away build stage to reduce size of final image
+FROM base as build
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,0 +1,56 @@
+# syntax = docker/dockerfile:1
+
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+ARG RUBY_VERSION=3.1.2
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
+
+# Install packages needed to build gems and node modules
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
+
+# Install JavaScript dependencies
+# Make sure NODE_VERSION matches the node version in .nvmrc
+ARG NODE_VERSION=18.13.0
+ARG YARN_VERSION=1.22.19
+ENV PATH=/usr/local/node/bin:$PATH
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    npm install -g yarn@$YARN_VERSION && \
+    rm -rf /tmp/node-build-master
+
+# Rails app lives here
+WORKDIR /app
+
+# Set production environment
+ENV RAILS_ENV="production" \
+    BUNDLE_DEPLOYMENT="1" \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development"
+
+
+# Throw-away build stage to reduce size of final image
+FROM base as build
+
+# Install application gems
+COPY Gemfile Gemfile.lock ./
+RUN bundle install && \
+    rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git
+
+# Install node modules
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# Copy application code
+COPY . .
+
+# Final stage for app image
+FROM base
+
+# Install packages needed for deployment
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y curl libvips postgresql-client && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy built artifacts: gems, application
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build /app /app

--- a/Dockerfile_base
+++ b/Dockerfile_base
@@ -1,5 +1,9 @@
 # syntax = docker/dockerfile:1
 
+# This Dockerfile is to build a base image and push it to the Docker hub for a faster
+# build process. To use the image built from this file in your cpln deployment, check
+# the `.controlplane/controlplane.yml` file and uncomment the line related to Dockerfile.
+
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.1.2
 FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+# If running the rails server then create or migrate existing database
+if [ "${1}" == "./bin/rails" ] && [ "${2}" == "server" ]; then
+  ./bin/rails db:prepare
+fi
+
+exec "${@}"

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -1,0 +1,22 @@
+# Guidelines for maintainers
+
+## Deployment on Control Plane
+
+The simple yet longer process of building and deploying this project on Control Plane is to use the default files in the `.controlplane` directory.
+It is especially easier and more flexible for deployment during project development.
+
+To get a faster Docker image build process,
+after each change on the project,
+the maintainer should push a new image to the docker hub using the `Dockerfile_base` to update the base image.
+
+```
+docker build -f ./Dockerfile_base -t rwrt-base .
+docker image tag rwrt-base:latest shakacode/rwrt-base:latest
+docker image push shakacode/rwrt-base:latest
+```
+
+After successfully building the base image and pushing it to the Dockerhub,
+build the project from `Dockerfile_from_base`.
+This Dockerfile uses the base image from the Docker hub.
+For this, uncomment the line for the custom Dockerfile in the `controlplane.yml` file.
+Then run `cpln build-image ...` command.


### PR DESCRIPTION
Creating a base Dockerfile for this project so that it can be used in `.controlplane/Dockerfile` to speed up the build time.

- This file is based on Rails 7.1 Dockerfile.
- The Docker base image should be built from `Dockerfile_base` and pushed to the Docker hub.
- For deploying on Control Plane, we should use `.controlplane/Dockerfile_from_base`. For this, we need to uncomment the line for the custom Dockerfile path in `.controlplane/controlplane.yml` file.

These new Dockerfiles are made originally with the idea of having a way to make a faster build/deploy process on cpln. We still need the existing Dockerfiles to have more control and flexibility when experimenting with deployment. 

## Result:
![Screenshot from 2023-12-09 19-36-43-e](https://github.com/shakacode/react-webpack-rails-tutorial/assets/11241315/adf8c7c7-3e7f-422a-ac77-15224020386d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/563)
<!-- Reviewable:end -->
