### PR TITLE
Include `.git` directory in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,7 +44,6 @@ yarn-debug.log*
 
 ###################################################
 # Specific to .dockerignore
-.git/
 .github/
 spec/
 scripts/


### PR DESCRIPTION
We need to have the `.git` directory in the deployed project to get and show the commit hash of the deployed project.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/569)
<!-- Reviewable:end -->
