### PR TITLE
Add ActionCable to rescript (#565)

### DIFF
--- a/app/views/pages/rescript.html.erb
+++ b/app/views/pages/rescript.html.erb
@@ -1,1 +1,1 @@
-<%= react_component "RescriptShow", prerender: false %>
+<%= react_component "RescriptShow", prerender: true %>

--- a/app/views/pages/rescript.html.erb
+++ b/app/views/pages/rescript.html.erb
@@ -1,1 +1,1 @@
-<%= react_component "RescriptShow", prerender: true %>
+<%= react_component "RescriptShow", prerender: false %>

--- a/client/app/bundles/comments/rescript/ReScriptShow.res
+++ b/client/app/bundles/comments/rescript/ReScriptShow.res
@@ -15,6 +15,10 @@ let reducer = (_, action: action): state => {
   }
 }
 
+type subscriptionStatus =
+  | Disconnected(ActionCable.subscription<unit>)
+  | Connected(ActionCable.subscription<unit>)
+
 @react.component
 let default = () => {
   let (state, dispatch) = React.useReducer(
@@ -31,6 +35,25 @@ let default = () => {
     | Error(_) => SetFetchError->dispatch
     }
   }
+
+  let subscribeToCommentsChannel = () => {
+    let _ = ActionCable.subscribeConsumer(
+      "CommentsChannel",
+      {
+        connected: () => {
+          Js.Console.log("Connected")
+        },
+        received: (data: Actions.Fetch.t) => {
+          SetComments([data])->dispatch
+        },
+        disconnected: () => {
+          Js.Console.log("Disconnected")
+        },
+      },
+    )
+  }
+
+  subscribeToCommentsChannel()
 
   React.useEffect1(_ => {
     fetchData()->ignore

--- a/client/app/bundles/comments/rescript/ReScriptShow.res
+++ b/client/app/bundles/comments/rescript/ReScriptShow.res
@@ -37,7 +37,7 @@ let default = () => {
   }
 
   let subscribeToCommentsChannel = () => {
-    let _ = ActionCable.subscribeConsumer(
+    ActionCable.subscribeConsumer(
       "CommentsChannel",
       {
         connected: () => {
@@ -53,7 +53,13 @@ let default = () => {
     )
   }
 
-  subscribeToCommentsChannel()
+  React.useEffect1(_ => {
+    let scription = subscribeToCommentsChannel()
+
+    Some(() => {
+      ActionCable.unsubscribeSubscription(scription)
+    })
+  }, [])
 
   React.useEffect1(_ => {
     fetchData()->ignore

--- a/client/app/bundles/comments/rescript/ReScriptShow.res
+++ b/client/app/bundles/comments/rescript/ReScriptShow.res
@@ -56,9 +56,11 @@ let default = () => {
   React.useEffect1(_ => {
     let scription = subscribeToCommentsChannel()
 
-    Some(() => {
-      ActionCable.unsubscribeSubscription(scription)
-    })
+    Some(
+      () => {
+        ActionCable.unsubscribeSubscription(scription)
+      },
+    )
   }, [])
 
   React.useEffect1(_ => {

--- a/client/app/bundles/comments/rescript/bindings/ActionCable.res
+++ b/client/app/bundles/comments/rescript/bindings/ActionCable.res
@@ -1,0 +1,39 @@
+type webSocket
+type optionalWebSocket = option<webSocket>
+type subscriptions
+type consumer = {
+  disconnect: unit => unit,
+  subscriptions: subscriptions,
+}
+type actionCable = {createConsumer: unit => consumer}
+type createConsumer
+type subscription<'sendData> = {
+  consumer: consumer,
+  send: 'sendData => unit,
+}
+type subscriprtionCallbacks<'updateData> = {
+  connected: unit => unit,
+  received: 'updateData => unit,
+  disconnected: unit => unit,
+}
+
+@val @scope("window") @return(nullable)
+external webSocket: option<webSocket> = "WebSocket"
+@val external actionCable: actionCable = "ActionCable"
+@send
+external createSubscription: (
+  subscriptions,
+  string,
+  subscriprtionCallbacks<'updateData>,
+) => subscription<'sendData'> = "create"
+@send external sendData: (subscription<'sendData>, 'sendData) => unit = "send"
+@send external unsubscribeSubscription: subscription<'sendData'> => unit = "unsubscribe"
+@send external diconnectConsumer: consumer => unit = "disconnect"
+
+let subscribeConsumer = (
+  channnelName: string,
+  subscriprtionCallbacks: subscriprtionCallbacks<'updateData>,
+) => {
+  let consumer = actionCable.createConsumer()
+  createSubscription(consumer.subscriptions, channnelName, subscriprtionCallbacks)
+}


### PR DESCRIPTION
Adding ActionCable to the Rescript page to receive the new broadcasted comments. see the [js example](https://github.com/shakacode/react-webpack-rails-tutorial/blob/764a299e7e7e5f0643523d1aa691fcb7a87d4f99/client/app/bundles/comments/components/CommentBox/CommentBox.jsx#L35C7-L35C7)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/570)
<!-- Reviewable:end -->
