### PR TITLE
chore: add missing setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ See package.json and Gemfile for versions
 1. `cd react-webpack-rails-tutorial`
 1. `bundle install`
 1. `yarn`
-1. `rake db:setup`
-1. `rails start`
+1. `yarn res:dev && yarn build:dev`
+1. `rake db:setup && rake db:schema:load`
+1. `rails s`
     - Open a browser tab to http://localhost:3000 for the Rails app example
 
 ### Basic Command Line

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ See package.json and Gemfile for versions
 1. `cd react-webpack-rails-tutorial`
 1. `bundle install`
 1. `yarn`
-1. `yarn res:dev && yarn build:dev`
+1. `yarn rescript build && yarn build:dev`
 1. `rake db:setup && rake db:schema:load`
 1. `rails s`
     - Open a browser tab to http://localhost:3000 for the Rails app example


### PR DESCRIPTION
Some steps that are required for the demo to work are missing. Additionaly `rails start` command is actually named `rails server`, but `s` is an alias for that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/590)
<!-- Reviewable:end -->
