### PR TITLE
Update Control Plane links

### DIFF
--- a/.controlplane/readme.md
+++ b/.controlplane/readme.md
@@ -21,7 +21,7 @@ You can see the definition of Postgres and Redis in the `.controlplane/templates
 
 ## Prerequisites
 
-1. Ensure your [Control Plane](https://controlplane.com) account is set up.
+1. Ensure your [Control Plane](https://shakacode.controlplane.com) account is set up.
 You should have an `organization` `<your-org>` for testing in that account.
 Set ENV variable `CPLN_ORG` to `<your-org>`. Alternatively, you may modify the 
 value for `aliases.common.cpln_org` in `.controlplane/controlplane.yml`.
@@ -31,7 +31,7 @@ If you need an organization, please [contact Shakacode](mailto:controlplane@shak
 You can update the `cpln` command line with `npm update -g @controlplane/cli`.
 Then run `cpln login` to ensure access.
 For more informatation check out the
-[docs here](https://docs.controlplane.com/quickstart/quick-start-3-cli#getting-started-with-the-cli).
+[docs here](https://shakadocs.controlplane.com/quickstart/quick-start-3-cli#getting-started-with-the-cli).
 
 3. Run `cpln image docker-login --org <your-org>` to ensure that you have access to the Control Plane Docker registry.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Control Plane Deployment Example
 
-[Control Plane](https://controlplane.com) offers a viable, cost-saving alternative to Heroku, especially when using the [cpl gem](https://rubygems.org/gems/cpl) to deploy to Control Plane.
+[Control Plane](https://shakacode.controlplane.com) offers a viable, cost-saving alternative to Heroku, especially when using the [cpl gem](https://rubygems.org/gems/cpl) to deploy to Control Plane.
 
 ShakaCode recently migrated [HiChee.com](https://hichee.com) to Control Plane, resulting in a two-thirds reduction in server hosting costs!
 

--- a/app/views/pages/_header.html.erb
+++ b/app/views/pages/_header.html.erb
@@ -14,7 +14,7 @@
     <li>
       This project is deployed on
       <%= link_to "Control Plane",
-                  "https://controlplane.com" %>
+                  "https://shakacode.controlplane.com" %>
       using
       <%= link_to "Heroku to Control Plane",
                   "https://github.com/shakacode/heroku-to-control-plane" %>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/591)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated URLs from `controlplane.com` to `shakacode.controlplane.com` for account setup and documentation links.

- **Style**
  - Updated the "Control Plane" link in the header to point to `shakacode.controlplane.com`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->