### PR TITLE
Rename cpl to cpflow

### DIFF
--- a/.controlplane/controlplane.yml
+++ b/.controlplane/controlplane.yml
@@ -1,8 +1,8 @@
-# Configuration for `cpl` commands.
+# Configuration for `cpflow` commands.
 
 # Keys beginning with "cpln_" correspond to your settings in Control Plane.
 
-# Global settings that apply to `cpl` usage.
+# Global settings that apply to `cpflow` usage.
 # You can opt out of allowing the use of CPLN_ORG and CPLN_APP env vars
 # to avoid any accidents with the wrong org / app.
 allow_org_override_by_env: true
@@ -13,7 +13,7 @@ aliases:
     # Org for staging and QA apps is typically set as an alias, shared by all apps, except for production apps.
     # Production apps will use a different org than staging for security.
     # Change this value to your org name
-    # or set ENV CPLN_ORG to your org name as that will override whatever is used here for all cpl commands
+    # or set ENV CPLN_ORG to your org name as that will override whatever is used here for all cpflow commands
     # cpln_org: shakacode-open-source-examples
 
     # Example apps use only location. CPLN offers the ability to use multiple locations.
@@ -53,7 +53,7 @@ apps:
     <<: *common
   # QA Apps are like Heroku review apps, but the use `prefix` so you can run a commmand like
   # this to create a QA app for the tutorial app.
-  # `cpl setup gvc postgres redis rails -a qa-react-webpack-rails-tutorial-pr-1234`
+  # `cpflow setup gvc postgres redis rails -a qa-react-webpack-rails-tutorial-pr-1234`
   qa-react-webpack-rails-tutorial:
     <<: *common
     # Prefix is used to identify these "qa" apps.

--- a/.controlplane/readme.md
+++ b/.controlplane/readme.md
@@ -6,13 +6,13 @@ _If you need a free demo account for Control Plane (no CC required), you can con
 
 ---
 
-Check [how the `cpl` gem (this project) is used in the Github actions](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.github/actions/deploy-to-control-plane/action.yml).
+Check [how the `cpflow` gem (this project) is used in the Github actions](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.github/actions/deploy-to-control-plane/action.yml).
 Here is a brief [video overview](https://www.youtube.com/watch?v=llaQoAV_6Iw).
 
 ---
 
 ## Overview
-This simple example shows how to deploy a simple app on Control Plane using the `cpl` gem.
+This simple example shows how to deploy a simple app on Control Plane using the `cpflow` gem.
 
 To maximize simplicity, this example creates Postgres and Redis as workloads in the same GVC as the app.
 In a real app, you would likely use persistent, external resources, such as AWS RDS and AWS ElastiCache.
@@ -36,7 +36,7 @@ For more informatation check out the
 3. Run `cpln image docker-login --org <your-org>` to ensure that you have access to the Control Plane Docker registry.
 
 4. Install the latest version of
-[`cpl` gem](https://rubygems.org/gems/cpl)
+[`cpflow` gem](https://rubygems.org/gems/cpflow)
 on your project's Gemfile or globally.
 For more information check out
 [Heroku to Control Plane](https://github.com/shakacode/heroku-to-control-plane).
@@ -46,14 +46,14 @@ You can use it as an example for your project.
 Ensure that you have Docker running.
 
 ### Tips
-Do not confuse the `cpl` CLI with the `cpln` CLI.
-The `cpl` CLI is the Heroku to Control Plane playbook CLI.
+Do not confuse the `cpflow` CLI with the `cpln` CLI.
+The `cpflow` CLI is the Heroku to Control Plane playbook CLI.
 The `cpln` CLI is the Control Plane CLI.
 
 ## Project Configuration
 See the filese in the `./controlplane` directory.
 
-1. `/templates`: defines the objects created with the `cpl setup` command.
+1. `/templates`: defines the objects created with the `cpflow setup` command.
 These YAML files are the same as used by the `cpln apply` command.
 2. `/controlplane.yml`: defines your application, including the organization, location, and app name.
 3. `Dockerfile`: defines the Docker image used to run the app on Control Plane.
@@ -65,7 +65,7 @@ Check if the Control Plane organization and location are correct in `.controlpla
 Alternatively, you can use `CPLN_ORG` environment variable to set the organization name.
 You should be able to see this information in the Control Plane UI.
 
-**Note:** The below commands use `cpl` which is the Heroku to Control Plane playbook gem,
+**Note:** The below commands use `cpflow` which is the Heroku to Control Plane playbook gem,
 and not `cpln` which is the Control Plane CLI.
 
 ```sh
@@ -74,23 +74,23 @@ export APP_NAME=react-webpack-rails-tutorial
 
 # Provision all infrastructure on Control Plane.
 # app react-webpack-rails-tutorial will be created per definition in .controlplane/controlplane.yml
-cpl apply-template gvc postgres redis rails daily-task -a $APP_NAME
+cpflow apply-template gvc postgres redis rails daily-task -a $APP_NAME
 
 # Build and push docker image to Control Plane repository
 # Note, may take many minutes. Be patient.
 # Check for error messages, such as forgetting to run `cpln image docker-login --org <your-org>`
-cpl build-image -a $APP_NAME
+cpflow build-image -a $APP_NAME
 
-# Promote image to app after running `cpl build-image command`
+# Promote image to app after running `cpflow build-image command`
 # Note, the UX of images may not show the image for up to 5 minutes.
 # However, it's ready.
-cpl deploy-image -a $APP_NAME
+cpflow deploy-image -a $APP_NAME
 
 # See how app is starting up
-cpl logs -a $APP_NAME
+cpflow logs -a $APP_NAME
 
 # Open app in browser (once it has started up)
-cpl open -a $APP_NAME
+cpflow open -a $APP_NAME
 ```
 
 ### Promoting code updates
@@ -100,22 +100,22 @@ After committing code, you will update your deployment of `react-webpack-rails-t
 ```sh
 # Assuming you have already set APP_NAME env variable to react-webpack-rails-tutorial
 # Build and push new image with sequential image tagging, e.g. 'react-webpack-rails-tutorial:1', then 'react-webpack-rails-tutorial:2', etc.
-cpl build-image -a $APP_NAME
+cpflow build-image -a $APP_NAME
 
 # Run database migrations (or other release tasks) with latest image,
 # while app is still running on previous image.
 # This is analogous to the release phase.
-cpl runner rails db:migrate -a $APP_NAME --image latest
+cpflow run -a $APP_NAME --image latest -- rails db:migrate
 
 # Pomote latest image to app after migrations run
-cpl deploy-image -a $APP_NAME
+cpflow deploy-image -a $APP_NAME
 ```
 
 If you needed to push a new image with a specific commit SHA, you can run the following command:
 
 ```sh
 # Build and push with sequential image tagging and commit SHA, e.g. 'react-webpack-rails-tutorial:123_ABCD'
-cpl build-image -a $APP_NAME --commit ABCD
+cpflow build-image -a $APP_NAME --commit ABCD
 ```
 
 ## Other notes

--- a/.github/actions/deploy-to-control-plane/action.yml
+++ b/.github/actions/deploy-to-control-plane/action.yml
@@ -27,14 +27,14 @@ runs:
       run: |
         sudo npm install -g @controlplane/cli
         cpln --version
-        gem install cpl -v 1.2.0
+        gem install cpflow -v 3.0.1
 
     - name: Set Short SHA
       id: vars
       shell: bash
       run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-    - name: cpl profile
+    - name: cpflow profile
       shell: bash
       run: |
         cpln profile update default
@@ -49,11 +49,11 @@ runs:
           ${{ runner.os }}-docker-${{ hashFiles('**/Dockerfile', '**/package.json', '**/yarn.lock') }}
           ${{ runner.os }}-docker-
 
-    - name: cpl build-image
+    - name: cpflow build-image
       shell: bash
       run: |
         cpln image docker-login
-        cpl build-image -a ${{ inputs.app_name }} --commit ${{steps.vars.outputs.sha_short}} --org ${{inputs.org}}
+        cpflow build-image -a ${{ inputs.app_name }} --commit ${{steps.vars.outputs.sha_short}} --org ${{inputs.org}}
         # --cache /tmp/.docker-cache 
 
     - name: Run release script
@@ -62,9 +62,9 @@ runs:
         # Run database migrations (or other release tasks) with the latest image,
         # while the app is still running on the previous image.
         # This is analogous to the release phase.
-        cpl run:detached './.controlplane/release_script.sh' -a ${{ inputs.app_name }}  --image latest
+        cpflow run './.controlplane/release_script.sh' -a ${{ inputs.app_name }}  --image latest
 
     - name: Deploy to Control Plane
       shell: bash
       run: |
-        cpl deploy-image -a ${{ inputs.app_name }} --org ${{inputs.org}}  
+        cpflow deploy-image -a ${{ inputs.app_name }} --org ${{inputs.org}}  

--- a/.github/actions/deploy-to-control-plane/action.yml
+++ b/.github/actions/deploy-to-control-plane/action.yml
@@ -25,9 +25,9 @@ runs:
     - name: Install Control Plane CLI
       shell: bash
       run: |
-        sudo npm install -g @controlplane/cli
+        sudo npm install -g @controlplane/cli@3.1.0
         cpln --version
-        gem install cpflow -v 3.0.1
+        gem install cpflow -v 4.0.0
 
     - name: Set Short SHA
       id: vars

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 ## Control Plane Deployment Example
 
-[Control Plane](https://shakacode.controlplane.com) offers a viable, cost-saving alternative to Heroku, especially when using the [cpl gem](https://rubygems.org/gems/cpl) to deploy to Control Plane.
+[Control Plane](https://shakacode.controlplane.com) offers a viable, cost-saving alternative to Heroku, especially when using the [cpflow gem](https://rubygems.org/gems/cpflow) to deploy to Control Plane.
 
 ShakaCode recently migrated [HiChee.com](https://hichee.com) to Control Plane, resulting in a two-thirds reduction in server hosting costs!
 
 See doc in [./.controlplane/readme.md](./.controlplane/readme.md) for how to easily deploy this app to Control Plane.
 
-The instructions leverage the `cpl` CLI, with source code and many more tips on how to migrate from Heroku to Control Plane
+The instructions leverage the `cpflow` CLI, with source code and many more tips on how to migrate from Heroku to Control Plane
 in https://github.com/shakacode/heroku-to-control-plane.
 
 ----


### PR DESCRIPTION
### Summary
- Renamed instances of `cpl` gem to `cpflow` as `cpl` gem is deprecated and updated some commands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/595)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated all references from `cpl` to `cpflow` in configuration files, documentation, and setup instructions.
	- Enhanced deployment commands to reflect the new `cpflow` tool.
	- Adjusted installation instructions to use `cpflow` gem version `4.0.0`.
	- Migrated example commands and environment variable references to align with `cpflow`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->