### PR TITLE
Feat: Trigger review-app workflow when '/deploy-review-app' is commented (basic implementation)

### DIFF
--- a/.github/workflows/deploy-to-control-plane-review.yml
+++ b/.github/workflows/deploy-to-control-plane-review.yml
@@ -6,6 +6,8 @@ name: Deploy Review App to Control Plane
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  issue_comment:
+    types: [created, edited]
 
 # Convert the GitHub secret variables to environment variables for use by the Control Plane CLI
 env:
@@ -14,6 +16,7 @@ env:
 
 jobs:
   deploy-to-control-plane-staging:
+    if: ${{ github.event_name != 'issue_comment' || (github.event.comment.body == '/deploy-review-app' && github.event.issue.pull_request) }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
A better implementation is added in #597 
To test comment triggers, the event trigger should be on master in this workflow file first. This change should enable testing the changes in #597 

source: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment
> Note: This event will only trigger a workflow run if the workflow file is on the default branch.
