### PR TITLE
Fix/no commit hash on the deployed project

### DIFF
--- a/.controlplane/Dockerfile
+++ b/.controlplane/Dockerfile
@@ -76,3 +76,7 @@ ENTRYPOINT ["./.controlplane/entrypoint.sh"]
 # Default args to pass to the entry point that can be overridden
 # For Kubernetes and ControlPlane, these are the "workload args"
 CMD ["./bin/rails", "server"]
+
+# Current commit hash environment variable
+ARG GIT_COMMIT_SHA
+ENV GIT_COMMIT_SHA=${GIT_COMMIT_SHA}

--- a/app/models/git_commit_sha.rb
+++ b/app/models/git_commit_sha.rb
@@ -5,7 +5,9 @@ class GitCommitSha
   attr_writer :current_sha
 
   def self.current_sha
-    @current_sha ||= retrieve_sha_from_file.presence || retrieve_sha_from_git
+    @current_sha ||= ENV["GIT_COMMIT_SHA"].presence ||
+                     retrieve_sha_from_file.presence ||
+                     retrieve_sha_from_git
   end
 
   def self.reset_current_sha

--- a/spec/system/pages_spec.rb
+++ b/spec/system/pages_spec.rb
@@ -17,13 +17,16 @@ describe "Git Commit SHA" do
     GitCommitSha.reset_current_sha
   end
 
-  context "when .source_version file does not exist" do
-    let(:sha) { "94d92356828a56db25fccff9d50f41c525eead5x" }
+  context "when GIT_COMMIT_SHA env var exists" do
+    let(:sha) { "94d92356828a56db25fccff9d50f41c525eead5z" }
     let(:expected_text) { "94d9235" }
 
     before do
-      # stub this method since we need to control what the sha actually is
-      allow(GitCommitSha).to receive(:retrieve_sha_from_git) { sha }
+      ENV["GIT_COMMIT_SHA"] = sha
+    end
+
+    after do
+      ENV.delete("GIT_COMMIT_SHA")
     end
 
     it_behaves_like "Git Commit SHA"
@@ -36,6 +39,18 @@ describe "Git Commit SHA" do
     before { `cd #{Rails.root} && echo #{sha} > .source_version` }
 
     after { `cd #{Rails.root} && rm .source_version` }
+
+    it_behaves_like "Git Commit SHA"
+  end
+
+  context "when falling back to git command" do
+    let(:sha) { "94d92356828a56db25fccff9d50f41c525eead5x" }
+    let(:expected_text) { "94d9235" }
+
+    before do
+      # stub this method since we need to control what the sha actually is
+      allow(GitCommitSha).to receive(:retrieve_sha_from_git) { sha }
+    end
 
     it_behaves_like "Git Commit SHA"
   end


### PR DESCRIPTION
Fixes #567 
Follows [this approach](https://github.com/shakacode/react-webpack-rails-tutorial/issues/567#issuecomment-2470668417)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/611)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added ability to track Git commit SHA through environment variable
	- Enhanced flexibility for retrieving current Git commit SHA

- **Tests**
	- Updated system tests to cover new Git commit SHA retrieval methods
	- Added test scenarios for environment variable and fallback mechanisms

- **Infrastructure**
	- Modified Dockerfile to support passing Git commit SHA as a build argument

<!-- end of auto-generated comment: release notes by coderabbit.ai -->