### PR TITLE
Yet Another PR to test Github Actions Workflows

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to delete review app for'
+        description: 'PR number of the review app targeted for deletion'
         required: true
         type: string
 

--- a/.github/workflows/deploy-to-control-plane-review-app.yml
+++ b/.github/workflows/deploy-to-control-plane-review-app.yml
@@ -5,7 +5,7 @@ run-name: Deploy PR Review App - PR #${{ github.event.pull_request.number || git
 # Controls when the workflow will run
 on:
   pull_request:
-    types: [synchronize, reopened]
+    types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -14,10 +14,6 @@ on:
         description: 'Pull Request number to deploy'
         required: true
         type: number
-
-concurrency:
-  group: deploy-pr-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
-  cancel-in-progress: true
 
 env:
   PREFIX: ${{ vars.REVIEW_APP_PREFIX }}


### PR DESCRIPTION
Testing if removing the concurrency limit enables the review app deployment workflow to work properly once triggered by the opening of this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/643)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the description text for the PR number input in the review app deletion workflow.
  - Adjusted the review app deployment workflow to trigger on newly opened pull requests and removed concurrency controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->