### PR TITLE
Demo of Github Action Workflow Changes

### DIFF
--- a/.github/workflows/deploy-to-control-plane-review-app.yml
+++ b/.github/workflows/deploy-to-control-plane-review-app.yml
@@ -32,33 +32,6 @@ jobs:
        contains(github.event.comment.body, '/deploy-review-app'))
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          token: ${{ secrets.CPLN_TOKEN_STAGING }}
-          org: ${{ vars.CPLN_ORG_STAGING }}
-
-      - name: Check if Review App Exists
-        id: check-app
-        env:
-          CPLN_TOKEN: ${{ secrets.CPLN_TOKEN_STAGING }}
-        run: |
-          # First check if cpflow exists
-          if ! command -v cpflow &> /dev/null; then
-            echo "Error: cpflow command not found"
-            exit 1
-          fi
-
-          # Check if app exists and save state
-          if ! cpflow exists -a ${{ env.APP_NAME }}; then
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              exit 0
-            fi
-            echo "APP_EXISTS=false" >> $GITHUB_ENV
-          else
-            echo "APP_EXISTS=true" >> $GITHUB_ENV
-          fi
-
       - name: Initial Checkout
         uses: actions/checkout@v4
 
@@ -119,6 +92,33 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.PR_SHA }}
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          token: ${{ secrets.CPLN_TOKEN_STAGING }}
+          org: ${{ vars.CPLN_ORG_STAGING }}
+
+      - name: Check if Review App Exists
+        id: check-app
+        env:
+          CPLN_TOKEN: ${{ secrets.CPLN_TOKEN_STAGING }}
+        run: |
+          # First check if cpflow exists
+          if ! command -v cpflow &> /dev/null; then
+            echo "Error: cpflow command not found"
+            exit 1
+          fi
+
+          # Check if app exists and save state
+          if ! cpflow exists -a ${{ env.APP_NAME }}; then
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              exit 0
+            fi
+            echo "APP_EXISTS=false" >> $GITHUB_ENV
+          else
+            echo "APP_EXISTS=true" >> $GITHUB_ENV
+          fi
 
       - name: Validate Deployment Request
         id: validate

--- a/.github/workflows/deploy-to-control-plane-review-app.yml
+++ b/.github/workflows/deploy-to-control-plane-review-app.yml
@@ -26,7 +26,6 @@ jobs:
   deploy:
     if: |
       (github.event_name == 'pull_request') ||
-      (github.event_name == 'push') ||
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'issue_comment' && 
        github.event.issue.pull_request && 
@@ -41,34 +40,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # For push events, try to find associated PR first
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            PR_DATA=$(gh pr list --head "${{ github.ref_name }}" --json number,headRefName,headRefOid --jq '.[0]')
-            if [[ -n "$PR_DATA" ]]; then
-              PR_NUMBER=$(echo "$PR_DATA" | jq -r .number)
-            else
-              echo "No PR found for branch ${{ github.ref_name }}, skipping deployment"
-              echo "DO_DEPLOY=false" >> $GITHUB_ENV
-              exit 0
-            fi
-          else
-            # Get PR number based on event type
-            case "${{ github.event_name }}" in
-              "workflow_dispatch")
-                PR_NUMBER="${{ github.event.inputs.pr_number }}"
-                ;;
-              "issue_comment")
-                PR_NUMBER="${{ github.event.issue.number }}"
-                ;;
-              "pull_request")
-                PR_NUMBER="${{ github.event.pull_request.number }}"
-                ;;
-              *)
-                echo "Error: Unsupported event type ${{ github.event_name }}"
-                exit 1
-                ;;
-            esac
-          fi
+          # Get PR number based on event type
+          case "${{ github.event_name }}" in
+            "workflow_dispatch")
+              PR_NUMBER="${{ github.event.inputs.pr_number }}"
+              ;;
+            "issue_comment")
+              PR_NUMBER="${{ github.event.issue.number }}"
+              ;;
+            "pull_request")
+              PR_NUMBER="${{ github.event.pull_request.number }}"
+              ;;
+            *)
+              echo "Error: Unsupported event type ${{ github.event_name }}"
+              exit 1
+              ;;
+          esac
 
           if [[ -z "$PR_NUMBER" ]]; then
             echo "Error: Could not determine PR number"

--- a/.github/workflows/deploy-to-control-plane-review-app.yml
+++ b/.github/workflows/deploy-to-control-plane-review-app.yml
@@ -32,6 +32,33 @@ jobs:
        contains(github.event.comment.body, '/deploy-review-app'))
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Environment
+        uses: ./.github/actions/setup-environment
+        with:
+          token: ${{ secrets.CPLN_TOKEN_STAGING }}
+          org: ${{ vars.CPLN_ORG_STAGING }}
+
+      - name: Check if Review App Exists
+        id: check-app
+        env:
+          CPLN_TOKEN: ${{ secrets.CPLN_TOKEN_STAGING }}
+        run: |
+          # First check if cpflow exists
+          if ! command -v cpflow &> /dev/null; then
+            echo "Error: cpflow command not found"
+            exit 1
+          fi
+
+          # Check if app exists and save state
+          if ! cpflow exists -a ${{ env.APP_NAME }}; then
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              exit 0
+            fi
+            echo "APP_EXISTS=false" >> $GITHUB_ENV
+          else
+            echo "APP_EXISTS=true" >> $GITHUB_ENV
+          fi
+
       - name: Initial Checkout
         uses: actions/checkout@v4
 
@@ -92,30 +119,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.PR_SHA }}
-
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          token: ${{ secrets.CPLN_TOKEN_STAGING }}
-          org: ${{ vars.CPLN_ORG_STAGING }}
-
-      - name: Check if Review App Exists
-        id: check-app
-        env:
-          CPLN_TOKEN: ${{ secrets.CPLN_TOKEN_STAGING }}
-        run: |
-          # First check if cpflow exists
-          if ! command -v cpflow &> /dev/null; then
-            echo "Error: cpflow command not found"
-            exit 1
-          fi
-
-          # Check if app exists and save state
-          if ! cpflow exists -a ${{ env.APP_NAME }}; then
-            echo "APP_EXISTS=false" >> $GITHUB_ENV
-          else
-            echo "APP_EXISTS=true" >> $GITHUB_ENV
-          fi
 
       - name: Validate Deployment Request
         id: validate

--- a/.github/workflows/deploy-to-control-plane-review-app.yml
+++ b/.github/workflows/deploy-to-control-plane-review-app.yml
@@ -5,7 +5,7 @@ run-name: Deploy PR Review App - PR #${{ github.event.pull_request.number || git
 # Controls when the workflow will run
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [synchronize, reopened]
   issue_comment:
     types: [created]
   workflow_dispatch:

--- a/.github/workflows/help-command.yml
+++ b/.github/workflows/help-command.yml
@@ -27,7 +27,7 @@ jobs:
             const sections = {
               commands: {
                 deploy: {
-                  title: '## `/deploy`',
+                  title: '## `/deploy-review-app`',
                   purpose: '**Purpose:** Deploy a review app for your pull request',
                   details: [
                     '**What it does:**',
@@ -43,7 +43,7 @@ jobs:
                   ]
                 },
                 destroy: {
-                  title: '## `/destroy`',
+                  title: '## `/delete-review-app`',
                   purpose: '**Purpose:** Remove the review app for your pull request',
                   details: [
                     '**What it does:**',
@@ -94,9 +94,9 @@ jobs:
               cleanup: {
                 title: '## Automatic Cleanup',
                 details: [
-                  'Review apps are automatically destroyed when:',
+                  'Review apps are automatically deleted when:',
                   '1. The pull request is closed',
-                  '2. The `/destroy` command is used',
+                  '2. The `/delete-review-app` command is used',
                   '3. A new deployment is requested (old one is cleaned up first)'
                 ]
               },

--- a/client/app/bundles/comments/components/Footer/Footer.jsx
+++ b/client/app/bundles/comments/components/Footer/Footer.jsx
@@ -14,7 +14,7 @@ export default class Footer extends BaseComponent {
           </a>
           <a href="https://x.com/railsonmaui" className="flex gap-4 items-center">
             <div className="w-16 h-16 bg-[url('../images/twitter_64.png')]" />
-            Rails On Maui on X (Twitter)
+            Rails On Maui on X
           </a>
         </div>
       </footer>


### PR DESCRIPTION
Review Apps are no longer deployed on the opening of the PR, but are deployed by every following PR synchronization event (push, merge, etc) or by creation of a prompt comment.

Removal of the concurrency configuration stops deployment of the Review App from being canceled by a new comment (say, one by CodeRabbitAI, or by another user even) being created while the Review App deployment workflow is still in progress.

Nightly Removal of Stale Apps has been greatly simplifed & now works correctly.

Experiments revealed that workflows triggered by comment creation are run off the `master` branch instead of the PR base branch, which means that workflows triggered by comment creation must be tested through workflow dispatch.

Because workflows triggered by comment creation run off the `master` branch, two git checkouts were required for the Review App to deploy with the code changes of the PR's branch: the first checkout to initialize git (which would checkout `master`) & the second checkout to checkout the PR's HEAD ref.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/644)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow to trigger only on pull request synchronizations and reopenings, excluding new pull requests and push events.
  - Simplified pull request number resolution during deployment by removing push event handling.
  - Modified help command references from `/deploy` to `/deploy-review-app` and `/destroy` to `/delete-review-app`, updating related descriptions.

- **Style**
  - Changed the social link label to "Rails On Maui on X" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->