### PR TITLE
Convert test suite to run headless

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,9 @@ RSpec.configure do |config|
   # Ensure that if we are running js tests, we are using latest webpack assets
   # This will use the defaults of :js and :server_rendering meta tags
   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
+  
+  # Register the headless Chrome driver
+  DriverRegistration.register_selenium_chrome_headless
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join("spec/fixtures")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,6 @@ RSpec.configure do |config|
   # Ensure that if we are running js tests, we are using latest webpack assets
   # This will use the defaults of :js and :server_rendering meta tags
   ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
-  
   # Register the headless Chrome driver
   DriverRegistration.register_selenium_chrome_headless
 


### PR DESCRIPTION
## Summary
- Registered the headless Chrome driver to prevent browser windows from flashing during test runs
- Tests were already configured to use `selenium_chrome_headless` but the driver wasn't being registered

## Changes
- Added `DriverRegistration.register_selenium_chrome_headless` call in rails_helper.rb to properly initialize the headless driver
- The headless driver uses Chrome with `--headless`, `--disable-gpu`, `--no-sandbox`, and `--disable-dev-shm-usage` flags

## Test plan
- [x] Run `bundle exec rspec spec/rescript/rescript_spec.rb` and verify no browser window appears
- [x] Verify tests still pass with headless configuration

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/658)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Configured headless browser for UI/system tests to improve speed, reliability, and CI compatibility. Reduces flakiness, standardizes environments, lowers resource usage, and enables running suites without opening windows. No user-facing impact; development workflow becomes smoother and better suited for parallel runs, improves local setup consistency across teams, and reduces intermittent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->