### PR TITLE
Update Claude Code Review to use claude-sonnet-4-5-20250929

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model claude-sonnet-4-5-20250929 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 


### PR DESCRIPTION
## Summary
- Updated `.github/workflows/claude-code-review.yml` to use the latest Claude model `claude-sonnet-4-5-20250929`

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test on a new PR to confirm the review runs with the updated model

🤖 Generated with [Claude Code](https://claude.com/claude-code)