### PR TITLE
Migrate to Shakapacker 9.0.0-beta.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby "3.3.4"
 
 gem "react_on_rails", "16.1.1"
-gem "shakapacker", "9.0.0.beta.7"
+gem "shakapacker", "9.0.0.beta.8"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails"
 gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,7 +390,7 @@ GEM
       websocket (~> 1.0)
     semantic_range (3.1.0)
     sexp_processor (4.17.1)
-    shakapacker (9.0.0.beta.7)
+    shakapacker (9.0.0.beta.8)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -499,7 +499,7 @@ DEPENDENCIES
   scss_lint
   sdoc
   selenium-webdriver (~> 4)
-  shakapacker (= 9.0.0.beta.7)
+  shakapacker (= 9.0.0.beta.8)
   spring
   spring-commands-rspec
   stimulus-rails (~> 1.3)

--- a/config/webpack/commonWebpackConfig.js
+++ b/config/webpack/commonWebpackConfig.js
@@ -24,45 +24,49 @@ const ignoreWarningsConfig = {
 };
 
 const scssConfigIndex = baseClientWebpackConfig.module.rules.findIndex((config) =>
-  '.scss'.match(config.test),
+  '.scss'.match(config.test) && config.use,
 );
 
-// Configure sass-loader to use the modern API
-const scssRule = baseClientWebpackConfig.module.rules[scssConfigIndex];
-const sassLoaderIndex = scssRule.use.findIndex((loader) => {
-  if (typeof loader === 'string') {
-    return loader.includes('sass-loader');
+if (scssConfigIndex === -1) {
+  console.warn('No SCSS rule with use array found in webpack config');
+} else {
+  // Configure sass-loader to use the modern API
+  const scssRule = baseClientWebpackConfig.module.rules[scssConfigIndex];
+  const sassLoaderIndex = scssRule.use.findIndex((loader) => {
+    if (typeof loader === 'string') {
+      return loader.includes('sass-loader');
+    }
+    return loader.loader && loader.loader.includes('sass-loader');
+  });
+
+  if (sassLoaderIndex !== -1) {
+    const sassLoader = scssRule.use[sassLoaderIndex];
+    if (typeof sassLoader === 'string') {
+      scssRule.use[sassLoaderIndex] = {
+        loader: sassLoader,
+        options: {
+          api: 'modern'
+        }
+      };
+    } else {
+      sassLoader.options = sassLoader.options || {};
+      sassLoader.options.api = 'modern';
+    }
   }
-  return loader.loader && loader.loader.includes('sass-loader');
-});
 
-if (sassLoaderIndex !== -1) {
-  const sassLoader = scssRule.use[sassLoaderIndex];
-  if (typeof sassLoader === 'string') {
-    scssRule.use[sassLoaderIndex] = {
-      loader: sassLoader,
-      options: {
-        api: 'modern'
-      }
-    };
-  } else {
-    sassLoader.options = sassLoader.options || {};
-    sassLoader.options.api = 'modern';
+  // Fix css-loader configuration for CSS modules if namedExport is enabled
+  // When namedExport is true, exportLocalsConvention must be camelCaseOnly or dashesOnly
+  const cssLoader = scssRule.use.find((loader) => {
+    const loaderName = typeof loader === 'string' ? loader : loader?.loader;
+    return loaderName?.includes('css-loader');
+  });
+
+  if (cssLoader?.options?.modules?.namedExport) {
+    cssLoader.options.modules.exportLocalsConvention = 'camelCaseOnly';
   }
+
+  baseClientWebpackConfig.module.rules[scssConfigIndex].use.push(sassLoaderConfig);
 }
-
-// Fix css-loader configuration for CSS modules if namedExport is enabled
-// When namedExport is true, exportLocalsConvention must be camelCaseOnly or dashesOnly
-const cssLoader = scssRule.use.find(loader => {
-  const loaderName = typeof loader === 'string' ? loader : loader?.loader;
-  return loaderName?.includes('css-loader');
-});
-
-if (cssLoader?.options?.modules?.namedExport) {
-  cssLoader.options.modules.exportLocalsConvention = 'camelCaseOnly';
-}
-
-baseClientWebpackConfig.module.rules[scssConfigIndex].use.push(sassLoaderConfig);
 
 // Copy the object using merge b/c the baseClientWebpackConfig and commonOptions are mutable globals
 const commonWebpackConfig = () => merge({}, baseClientWebpackConfig, commonOptions, ignoreWarningsConfig);

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "sass": "^1.58.3",
     "sass-loader": "^13.3.2",
     "sass-resources-loader": "^2.2.5",
-    "shakapacker": "9.0.0-beta.7",
+    "shakapacker": "9.0.0-beta.8",
     "stimulus": "^3.0.1",
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8263,10 +8263,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@9.0.0-beta.7:
-  version "9.0.0-beta.7"
-  resolved "https://registry.npmjs.org/shakapacker/-/shakapacker-9.0.0-beta.7.tgz#c00b9590b84f365bf0fd4e7b7efdd59104901a00"
-  integrity sha512-m4xGyTg9yy4ys+wz44jBdygsxwKDbARBlgYqsyirwowQKWZHqnyb+ucS9yz5cKQHUtHeDlJOhPHKhRsCwhJcDQ==
+shakapacker@9.0.0-beta.8:
+  version "9.0.0-beta.8"
+  resolved "https://registry.npmjs.org/shakapacker/-/shakapacker-9.0.0-beta.8.tgz#ab951f8ab575d1c178639c2048a296ae27c9a467"
+  integrity sha512-NPu5cTB6lL/Bzl8XDl1NfjlljLARWPH9YhjIh1CvXEuSdaNP2qJLSiIr68Bqv3IGHQmqtifgRl1iXQB8pNnAfQ==
   dependencies:
     js-yaml "^4.1.0"
     path-complete-extname "^1.0.0"


### PR DESCRIPTION
## Summary
Updates Shakapacker from 9.0.0-beta.7 to 9.0.0-beta.8.

## Changes
- Updated Shakapacker version in `Gemfile` and `package.json`
- Fixed `commonWebpackConfig.js` to properly detect SCSS rules with the new webpack config structure in beta.8
- Added null safety checks for SCSS rule properties

## Technical Details
In beta.8, the webpack rules structure changed to include a new `oneOf` pattern at index 0 that matches `.scss` but doesn't have a `use` array. The fix ensures we find the SCSS rule that actually has loaders configured.

## Test Plan
- [x] Build passes (`yarn build:test`)
- [x] RuboCop linter passes
- [x] No extraneous changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/665)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safety guard to SCSS processing so builds no longer fail when certain SCSS configurations are absent; reduces build errors and logs a warning in those cases.

* **Chores**
  * Upgraded shakapacker to 9.0.0-beta.8 for improved compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->