### PR TITLE
Fix FOUC by moving stylesheet loading to head (#TBD)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <title>RailsReactTutorial</title>
 
   <%= append_stylesheet_pack_tag('stimulus-bundle') %>
+  <%= stylesheet_pack_tag(media: 'all', 'data-turbolinks-track': true) %>
   <%= append_javascript_pack_tag('stimulus-bundle') %>
   <%= append_javascript_pack_tag('stores-registration') %>
 
@@ -20,7 +21,6 @@
 
   <%= react_component "Footer" %>
 
-  <%= stylesheet_pack_tag(media: 'all', 'data-turbolinks-track': true) %>
   <%= javascript_pack_tag('data-turbolinks-track': true, defer: true) %>
 
   <!-- This is a placeholder for ReactOnRails to know where to render the store props for

--- a/app/views/layouts/stimulus_layout.html.erb
+++ b/app/views/layouts/stimulus_layout.html.erb
@@ -6,6 +6,7 @@
   <title>RailsReactTutorial</title>
 
   <%= append_stylesheet_pack_tag('stimulus-bundle') %>
+  <%= stylesheet_pack_tag(media: 'all', 'data-turbolinks-track': true) %>
   <%= append_javascript_pack_tag('stimulus-bundle') %>
 
   <%= csrf_meta_tags %>
@@ -19,7 +20,6 @@
 
   <%= react_component "Footer" %>
 
-  <%= stylesheet_pack_tag(media: 'all', 'data-turbolinks-track': true) %>
   <%= javascript_pack_tag('data-turbolinks-track': true, defer: true) %>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Moved `stylesheet_pack_tag` from bottom of `<body>` to `<head>` section in application.html.erb
- Fixes flash of unstyled content (FOUC) visible on https://staging.reactrails.com/ and other pages

## Problem
The stylesheet was loading at the end of the body (line 23), after React components had already started rendering. This caused a noticeable FOUC where:
- Navigation bar and content appeared unstyled initially
- Tailwind CSS classes weren't applied until after page load
- User experience was poor with visible style flashing

## Solution
Stylesheets should always be loaded in the `<head>` to ensure styles are available before any content renders. The `stylesheet_pack_tag` is now loaded in the head alongside other pack tags, while JavaScript remains deferred at the bottom for optimal performance.

## Test Plan
- [ ] Visit https://staging.reactrails.com/ and verify no FOUC
- [ ] Navigate to https://staging.reactrails.com/no-router and verify no FOUC
- [ ] Check all pages load with styles immediately applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shakacode/react-webpack-rails-tutorial/684)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents flashes of unstyled content and inconsistent styling during page transitions by ensuring styles load earlier in the document head.
  * Improves visual stability and reduces layout shifts when navigating between views.

* **Refactor**
  * Moved stylesheet loading to the document head for more predictable rendering while leaving script loading behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->