### PR TITLE
Fix Claude Code Review workflow permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,5 +7,10 @@ on:
 jobs:
   claude-review:
     uses: shakacode/.github/.github/workflows/claude-code-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `permissions` block to the Claude Code Review caller workflow
- The reusable workflow in `shakacode/.github` needs `issues: write`, `pull-requests: write`, and `id-token: write`, but callers must explicitly grant these permissions
- Without this, the workflow fails with: "The nested job is requesting permissions but is only allowed none"

## Test plan
- [ ] Verify the Claude Code Review workflow runs successfully on a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to ensure proper operation of automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->