### PR TITLE
Pro RSC migration 3/3: React Server Components demo on webpack

### DIFF
--- a/.controlplane/templates/app.yml
+++ b/.controlplane/templates/app.yml
@@ -34,6 +34,10 @@ spec:
       value: '2'
     - name: RENDERER_URL
       value: http://localhost:3800
+    # Enable the artificial Suspense demo delay so the streaming fallback is
+    # visible on the review-app. Off by default in production deployments.
+    - name: RSC_SUSPENSE_DEMO_DELAY
+      value: 'true'
     # RENDERER_PASSWORD and REACT_ON_RAILS_PRO_LICENSE must be created in the
     # Control Plane Secret named by {{APP_SECRETS}} before deploy. cpflow
     # resolves {{APP_SECRETS}} to `{APP_PREFIX}-secrets` — which means review

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -12,4 +12,6 @@ rails: bundle exec thrust bin/rails server -p 3000
 wp-client: RAILS_ENV=development NODE_ENV=development bin/shakapacker-dev-server
 # Server webpack watcher for SSR bundle
 wp-server: SERVER_BUNDLE_ONLY=yes bin/shakapacker --watch
+# RSC webpack watcher for React Server Components bundle
+wp-rsc: RSC_BUNDLE_ONLY=yes bin/shakapacker --watch
 node-renderer: NODE_ENV=development node renderer/node-renderer.js

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,7 @@
 
 class PagesController < ApplicationController
   include ReactOnRails::Controller
+  include ReactOnRailsPro::Stream
   before_action :set_comments
 
   def index
@@ -38,7 +39,11 @@ class PagesController < ApplicationController
 
   def rescript; end
 
-  def server_components; end
+  def server_components
+    @server_components_comments = Comment.order(id: :desc).limit(10)
+                                         .as_json(only: %i[id author text created_at])
+    stream_view_containing_react_components(template: "/pages/server_components")
+  end
 
   private
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,7 @@
 class PagesController < ApplicationController
   include ReactOnRails::Controller
   include ReactOnRailsPro::Stream
-  before_action :set_comments
+  before_action :set_comments, only: %i[index no_router]
 
   def index
     # NOTE: The below notes apply if you want to set the value of the props in the controller, as

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -41,7 +41,7 @@ class PagesController < ApplicationController
 
   def server_components
     @server_components_comments = Comment.order(id: :desc).limit(10)
-                                         .as_json(only: %i[id author text created_at])
+                                         .as_json(only: %i[id author text created_at updated_at])
     stream_view_containing_react_components(template: "/pages/server_components")
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -38,6 +38,8 @@ class PagesController < ApplicationController
 
   def rescript; end
 
+  def server_components; end
+
   private
 
   def set_comments

--- a/app/views/pages/server_components.html.erb
+++ b/app/views/pages/server_components.html.erb
@@ -1,0 +1,5 @@
+<%= react_component("ServerComponentsPage",
+    prerender: false,
+    auto_load_bundle: false,
+    trace: Rails.env.development?,
+    id: "ServerComponentsPage-react-component-0") %>

--- a/app/views/pages/server_components.html.erb
+++ b/app/views/pages/server_components.html.erb
@@ -1,5 +1,5 @@
 <%= react_component("ServerComponentsPage",
     prerender: false,
-    auto_load_bundle: false,
+    auto_load_bundle: true,
     trace: Rails.env.development?,
     id: "ServerComponentsPage-react-component-0") %>

--- a/app/views/pages/server_components.html.erb
+++ b/app/views/pages/server_components.html.erb
@@ -2,5 +2,4 @@
     props: { comments: @server_components_comments },
     prerender: true,
     auto_load_bundle: true,
-    trace: Rails.env.development?,
-    id: "ServerComponentsPage-react-component-0") %>
+    trace: Rails.env.development?) %>

--- a/app/views/pages/server_components.html.erb
+++ b/app/views/pages/server_components.html.erb
@@ -1,5 +1,6 @@
-<%= react_component("ServerComponentsPage",
-    prerender: false,
+<%= stream_react_component("ServerComponentsPage",
+    props: { comments: @server_components_comments },
+    prerender: true,
     auto_load_bundle: true,
     trace: Rails.env.development?,
     id: "ServerComponentsPage-react-component-0") %>

--- a/client/app/bundles/comments/components/Footer/ror_components/Footer.jsx
+++ b/client/app/bundles/comments/components/Footer/ror_components/Footer.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import BaseComponent from 'libs/components/BaseComponent';

--- a/client/app/bundles/comments/components/NavigationBar/NavigationBar.jsx
+++ b/client/app/bundles/comments/components/NavigationBar/NavigationBar.jsx
@@ -104,6 +104,14 @@ function NavigationBar(props) {
             </li>
             <li>
               <a
+                className={navItemClassName(pathname === paths.SERVER_COMPONENTS_PATH)}
+                href={paths.SERVER_COMPONENTS_PATH}
+              >
+                RSC Demo
+              </a>
+            </li>
+            <li>
+              <a
                 className={navItemClassName(false)}
                 href="https://github.com/shakacode/react-webpack-rails-tutorial"
               >

--- a/client/app/bundles/comments/components/SimpleCommentScreen/ror_components/SimpleCommentScreen.jsx
+++ b/client/app/bundles/comments/components/SimpleCommentScreen/ror_components/SimpleCommentScreen.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 // eslint-disable-next-line max-classes-per-file
 import React from 'react';
 import request from 'axios';

--- a/client/app/bundles/comments/constants/paths.js
+++ b/client/app/bundles/comments/constants/paths.js
@@ -5,3 +5,4 @@ export const RESCRIPT_PATH = '/rescript';
 export const SIMPLE_REACT_PATH = '/simple';
 export const STIMULUS_PATH = '/stimulus';
 export const RAILS_PATH = '/comments';
+export const SERVER_COMPONENTS_PATH = '/server-components';

--- a/client/app/bundles/comments/rescript/ReScriptShow/ror_components/RescriptShow.jsx
+++ b/client/app/bundles/comments/rescript/ReScriptShow/ror_components/RescriptShow.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Wrapper for ReScript component to work with react_on_rails auto-registration
 // react_on_rails looks for components in ror_components/ subdirectories
 

--- a/client/app/bundles/comments/startup/App/ror_components/App.jsx
+++ b/client/app/bundles/comments/startup/App/ror_components/App.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Provider } from 'react-redux';
 import React from 'react';
 import ReactOnRails from 'react-on-rails-pro';

--- a/client/app/bundles/comments/startup/NavigationBarApp/ror_components/NavigationBarApp.jsx
+++ b/client/app/bundles/comments/startup/NavigationBarApp/ror_components/NavigationBarApp.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Top level component for client side.
 // Compare this to the ./ServerApp.jsx file which is used for server side rendering.
 

--- a/client/app/bundles/comments/startup/RouterApp/ror_components/RouterApp.client.jsx
+++ b/client/app/bundles/comments/startup/RouterApp/ror_components/RouterApp.client.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Compare to ./RouterApp.server.jsx
 import { Provider } from 'react-redux';
 import React from 'react';

--- a/client/app/bundles/comments/startup/RouterApp/ror_components/RouterApp.server.jsx
+++ b/client/app/bundles/comments/startup/RouterApp/ror_components/RouterApp.server.jsx
@@ -1,3 +1,5 @@
+'use client';
+
 // Compare to ./RouterApp.client.jsx
 import { Provider } from 'react-redux';
 import React from 'react';

--- a/client/app/bundles/server-components/ServerComponentsPage.jsx
+++ b/client/app/bundles/server-components/ServerComponentsPage.jsx
@@ -1,0 +1,129 @@
+// Server Component - this entire component runs on the server.
+// It can use Node.js APIs and server-only dependencies directly.
+// None of these imports are shipped to the client bundle.
+
+import React, { Suspense } from 'react';
+import ServerInfo from './components/ServerInfo';
+import CommentsFeed from './components/CommentsFeed';
+import TogglePanel from './components/TogglePanel';
+
+const ServerComponentsPage = () => {
+  return (
+    <div className="max-w-4xl mx-auto py-8 px-4">
+      <header className="mb-10">
+        <h1 className="text-3xl font-bold text-slate-800 mb-2">
+          React Server Components Demo
+        </h1>
+        <p className="text-slate-600 text-lg">
+          This page is rendered using <strong>React Server Components</strong> with React on Rails Pro.
+          Server components run on the server and stream their output to the client, keeping
+          heavy dependencies out of the browser bundle entirely.
+        </p>
+      </header>
+
+      <div className="space-y-8">
+        {/* Server Info - uses Node.js os module (impossible on client) */}
+        <section>
+          <h2 className="text-xl font-semibold text-slate-700 mb-4 flex items-center gap-2">
+            Server Environment
+            <span className="text-xs font-normal bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded-full">
+              Server Only
+            </span>
+          </h2>
+          <ServerInfo />
+        </section>
+
+        {/* Interactive toggle - demonstrates mixing server + client components */}
+        <section>
+          <h2 className="text-xl font-semibold text-slate-700 mb-4 flex items-center gap-2">
+            Interactive Client Component
+            <span className="text-xs font-normal bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full">
+              Client Hydrated
+            </span>
+          </h2>
+          <TogglePanel title="How does this work?">
+            <div className="prose prose-slate max-w-none text-sm">
+              <p>
+                This toggle is a <code>&apos;use client&apos;</code> component, meaning it ships JavaScript
+                to the browser for interactivity. But the content inside is rendered on the server
+                and passed as children — a key RSC pattern called the <strong>donut pattern</strong>.
+              </p>
+              <ul>
+                <li>The <code>TogglePanel</code> wrapper runs on the client (handles click events)</li>
+                <li>The children content is rendered on the server (no JS cost)</li>
+                <li>Heavy libraries used by server components never reach the browser</li>
+              </ul>
+            </div>
+          </TogglePanel>
+        </section>
+
+        {/* Async data fetching with Suspense streaming */}
+        <section>
+          <h2 className="text-xl font-semibold text-slate-700 mb-4 flex items-center gap-2">
+            Streamed Comments
+            <span className="text-xs font-normal bg-amber-100 text-amber-700 px-2 py-0.5 rounded-full">
+              Async + Suspense
+            </span>
+          </h2>
+          <p className="text-slate-500 text-sm mb-4">
+            Comments are fetched directly on the server using the Rails API.
+            The page shell renders immediately while this section streams in progressively.
+          </p>
+          <Suspense
+            fallback={
+              <div className="animate-pulse space-y-3">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="bg-slate-100 rounded-lg p-4">
+                    <div className="h-4 bg-slate-200 rounded w-1/4 mb-2" />
+                    <div className="h-3 bg-slate-200 rounded w-3/4" />
+                  </div>
+                ))}
+              </div>
+            }
+          >
+            <CommentsFeed />
+          </Suspense>
+        </section>
+
+        {/* Architecture explanation */}
+        <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
+          <h2 className="text-lg font-semibold text-slate-700 mb-3">
+            What makes this different?
+          </h2>
+          <div className="grid md:grid-cols-2 gap-4 text-sm text-slate-600">
+            <div>
+              <h3 className="font-medium text-slate-800 mb-1">Smaller Client Bundle</h3>
+              <p>
+                Libraries like <code>lodash</code>, <code>marked</code>, and Node.js <code>os</code> module
+                are used on this page but never downloaded by the browser.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium text-slate-800 mb-1">Direct Data Access</h3>
+              <p>
+                Server components fetch data by calling your Rails API internally — no
+                client-side fetch waterfalls or loading spinners for initial data.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium text-slate-800 mb-1">Progressive Streaming</h3>
+              <p>
+                The page shell renders instantly. Async components (like the comments feed)
+                stream in as their data resolves, with Suspense boundaries showing fallbacks.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-medium text-slate-800 mb-1">Selective Hydration</h3>
+              <p>
+                Only client components (like the toggle above) receive JavaScript.
+                Everything else is pure HTML — zero hydration cost.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ServerComponentsPage;

--- a/client/app/bundles/server-components/components/CommentsFeed.jsx
+++ b/client/app/bundles/server-components/components/CommentsFeed.jsx
@@ -1,0 +1,129 @@
+// Server Component - fetches comments directly from the Rails API on the server.
+// Uses marked for markdown rendering. Both fetch and marked stay server-side.
+
+import React from 'react';
+import { Marked } from 'marked';
+import { gfmHeadingId } from 'marked-gfm-heading-id';
+import sanitizeHtml from 'sanitize-html';
+import _ from 'lodash';
+import TogglePanel from './TogglePanel';
+
+const marked = new Marked();
+marked.use(gfmHeadingId());
+
+function resolveRailsBaseUrl() {
+  if (process.env.RAILS_INTERNAL_URL) {
+    return process.env.RAILS_INTERNAL_URL;
+  }
+
+  // Local defaults are okay in development/test, but production should be explicit.
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+    return 'http://localhost:3000';
+  }
+
+  throw new Error('RAILS_INTERNAL_URL must be set outside development/test');
+}
+
+async function CommentsFeed() {
+  // Simulate network latency only when explicitly enabled for demos.
+  if (process.env.RSC_SUSPENSE_DEMO_DELAY === 'true') {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 800);
+    });
+  }
+
+  let recentComments = [];
+  try {
+    // Fetch comments directly from the Rails API — no client-side fetch needed
+    const baseUrl = resolveRailsBaseUrl();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const response = await fetch(`${baseUrl}/comments.json`, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch comments: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json();
+    const comments = data.comments;
+
+    // Use lodash to process (stays on server)
+    const sortedComments = _.orderBy(comments, ['created_at'], ['desc']);
+    recentComments = _.take(sortedComments, 10);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('CommentsFeed failed to load comments', error);
+    return (
+      <div className="bg-rose-50 border border-rose-200 rounded-lg p-6 text-center">
+        <p className="text-rose-700">Could not load comments right now. Please try again later.</p>
+      </div>
+    );
+  }
+
+  if (recentComments.length === 0) {
+    return (
+      <div className="bg-amber-50 border border-amber-200 rounded-lg p-6 text-center">
+        <p className="text-amber-700">
+          No comments yet. Add some comments from the{' '}
+          <a href="/" className="underline font-medium">
+            home page
+          </a>{' '}
+          to see them rendered here by server components.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {recentComments.map((comment) => {
+        // Render markdown on the server using marked + sanitize-html.
+        // sanitize-html strips any dangerous HTML before rendering.
+        // These libraries (combined ~200KB) never reach the client.
+        const rawHtml = marked.parse(comment.text || '');
+        const safeHtml = sanitizeHtml(rawHtml, {
+          allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+          allowedAttributes: {
+            ...sanitizeHtml.defaults.allowedAttributes,
+            img: ['src', 'alt', 'title', 'width', 'height'],
+          },
+          allowedSchemes: ['https', 'http'],
+        });
+
+        return (
+          <div
+            key={comment.id}
+            className="bg-white border border-slate-200 rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <span className="font-semibold text-slate-800">{comment.author}</span>
+              <span className="text-xs text-slate-400">
+                {new Date(comment.created_at).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+            </div>
+            <TogglePanel title="Show rendered markdown">
+              {/* Content is sanitized via sanitize-html before rendering */}
+              {/* eslint-disable-next-line react/no-danger */}
+              <div
+                className="prose prose-sm prose-slate max-w-none"
+                dangerouslySetInnerHTML={{ __html: safeHtml }}
+              />
+            </TogglePanel>
+            <p className="text-slate-600 text-sm mt-1">{comment.text}</p>
+          </div>
+        );
+      })}
+      <p className="text-xs text-slate-400 text-center pt-2">
+        {recentComments.length} comment{recentComments.length !== 1 ? 's' : ''} rendered on the server using{' '}
+        <code>marked</code> + <code>sanitize-html</code> (never sent to browser)
+      </p>
+    </div>
+  );
+}
+
+export default CommentsFeed;

--- a/client/app/bundles/server-components/components/CommentsFeed.jsx
+++ b/client/app/bundles/server-components/components/CommentsFeed.jsx
@@ -7,10 +7,10 @@ import TogglePanel from './TogglePanel';
 const marked = new Marked();
 marked.use(gfmHeadingId());
 
-// Default-on small delay so the surrounding <Suspense> fallback is visible
-// in the demo. Set RSC_SUSPENSE_DEMO_DELAY=false to disable (CI / tests).
+// Opt-in delay so the surrounding <Suspense> fallback is visible in the demo.
+// Set RSC_SUSPENSE_DEMO_DELAY=true to enable; defaults off in production.
 async function CommentsFeed({ comments = [] }) {
-  if (process.env.RSC_SUSPENSE_DEMO_DELAY !== 'false') {
+  if (process.env.RSC_SUSPENSE_DEMO_DELAY === 'true') {
     await new Promise((resolve) => {
       setTimeout(resolve, 800);
     });

--- a/client/app/bundles/server-components/components/CommentsFeed.jsx
+++ b/client/app/bundles/server-components/components/CommentsFeed.jsx
@@ -1,65 +1,22 @@
-// Server Component - fetches comments directly from the Rails API on the server.
-// Uses marked for markdown rendering. Both fetch and marked stay server-side.
-
 import React from 'react';
 import { Marked } from 'marked';
 import { gfmHeadingId } from 'marked-gfm-heading-id';
 import sanitizeHtml from 'sanitize-html';
-import _ from 'lodash';
 import TogglePanel from './TogglePanel';
 
 const marked = new Marked();
 marked.use(gfmHeadingId());
 
-function resolveRailsBaseUrl() {
-  if (process.env.RAILS_INTERNAL_URL) {
-    return process.env.RAILS_INTERNAL_URL;
-  }
-
-  // Local defaults are okay in development/test, but production should be explicit.
-  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
-    return 'http://localhost:3000';
-  }
-
-  throw new Error('RAILS_INTERNAL_URL must be set outside development/test');
-}
-
-async function CommentsFeed() {
-  // Simulate network latency only when explicitly enabled for demos.
-  if (process.env.RSC_SUSPENSE_DEMO_DELAY === 'true') {
+// Default-on small delay so the surrounding <Suspense> fallback is visible
+// in the demo. Set RSC_SUSPENSE_DEMO_DELAY=false to disable (CI / tests).
+async function CommentsFeed({ comments = [] }) {
+  if (process.env.RSC_SUSPENSE_DEMO_DELAY !== 'false') {
     await new Promise((resolve) => {
       setTimeout(resolve, 800);
     });
   }
 
-  let recentComments = [];
-  try {
-    // Fetch comments directly from the Rails API — no client-side fetch needed
-    const baseUrl = resolveRailsBaseUrl();
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
-    const response = await fetch(`${baseUrl}/comments.json`, { signal: controller.signal });
-    clearTimeout(timeoutId);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch comments: ${response.status} ${response.statusText}`);
-    }
-    const data = await response.json();
-    const comments = data.comments;
-
-    // Use lodash to process (stays on server)
-    const sortedComments = _.orderBy(comments, ['created_at'], ['desc']);
-    recentComments = _.take(sortedComments, 10);
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('CommentsFeed failed to load comments', error);
-    return (
-      <div className="bg-rose-50 border border-rose-200 rounded-lg p-6 text-center">
-        <p className="text-rose-700">Could not load comments right now. Please try again later.</p>
-      </div>
-    );
-  }
-
-  if (recentComments.length === 0) {
+  if (comments.length === 0) {
     return (
       <div className="bg-amber-50 border border-amber-200 rounded-lg p-6 text-center">
         <p className="text-amber-700">
@@ -75,10 +32,8 @@ async function CommentsFeed() {
 
   return (
     <div className="space-y-3">
-      {recentComments.map((comment) => {
-        // Render markdown on the server using marked + sanitize-html.
-        // sanitize-html strips any dangerous HTML before rendering.
-        // These libraries (combined ~200KB) never reach the client.
+      {comments.map((comment) => {
+        // marked + sanitize-html (~200KB combined) stay server-side.
         const rawHtml = marked.parse(comment.text || '');
         const safeHtml = sanitizeHtml(rawHtml, {
           allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
@@ -119,7 +74,7 @@ async function CommentsFeed() {
         );
       })}
       <p className="text-xs text-slate-400 text-center pt-2">
-        {recentComments.length} comment{recentComments.length !== 1 ? 's' : ''} rendered on the server using{' '}
+        {comments.length} comment{comments.length !== 1 ? 's' : ''} rendered on the server using{' '}
         <code>marked</code> + <code>sanitize-html</code> (never sent to browser)
       </p>
     </div>

--- a/client/app/bundles/server-components/components/LiveActivityRefresher.jsx
+++ b/client/app/bundles/server-components/components/LiveActivityRefresher.jsx
@@ -3,26 +3,12 @@
 import React, { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import RSCRoute from 'react-on-rails-pro/RSCRoute';
-
-function ErrorFallback({ error, resetErrorBoundary }) {
-  return (
-    <div className="bg-rose-50 border border-rose-200 rounded-lg p-4">
-      <p className="text-rose-700 font-semibold mb-1">Server component fetch failed</p>
-      <p className="text-rose-600 text-sm font-mono mb-3">{error.message}</p>
-      <button
-        type="button"
-        onClick={resetErrorBoundary}
-        className="px-3 py-1.5 text-sm bg-rose-600 text-white rounded hover:bg-rose-700"
-      >
-        Retry
-      </button>
-    </div>
-  );
-}
+import { useRSC } from 'react-on-rails-pro/RSCProvider';
 
 const LiveActivityRefresher = () => {
   const [refreshKey, setRefreshKey] = useState(0);
   const [simulateError, setSimulateError] = useState(false);
+  const { refetchComponent } = useRSC();
 
   const handleRefresh = () => {
     setSimulateError(false);
@@ -32,6 +18,18 @@ const LiveActivityRefresher = () => {
   const handleSimulateError = () => {
     setSimulateError(true);
     setRefreshKey((k) => k + 1);
+  };
+
+  // refetchComponent primes the cache with corrected props before resetting
+  // the boundary, so the post-reset render hits cache instead of re-fetching.
+  const buildRetry = (resetErrorBoundary) => () => {
+    const newKey = refreshKey + 1;
+    setSimulateError(false);
+    setRefreshKey(newKey);
+    refetchComponent('LiveActivity', { simulateError: false, refreshKey: newKey })
+      // eslint-disable-next-line no-console
+      .catch((err) => console.error('Retry refetch failed:', err))
+      .finally(() => resetErrorBoundary());
   };
 
   return (
@@ -51,16 +49,22 @@ const LiveActivityRefresher = () => {
         >
           Simulate Error
         </button>
-        <span className="text-xs text-slate-500 ml-2">
-          Refresh count: {refreshKey}
-        </span>
+        <span className="text-xs text-slate-500 ml-2">Refresh count: {refreshKey}</span>
       </div>
       <ErrorBoundary
-        FallbackComponent={ErrorFallback}
-        onReset={() => {
-          setSimulateError(false);
-          setRefreshKey((k) => k + 1);
-        }}
+        fallbackRender={({ error, resetErrorBoundary }) => (
+          <div className="bg-rose-50 border border-rose-200 rounded-lg p-4">
+            <p className="text-rose-700 font-semibold mb-1">Server component fetch failed</p>
+            <p className="text-rose-600 text-sm font-mono mb-3">{error.message}</p>
+            <button
+              type="button"
+              onClick={buildRetry(resetErrorBoundary)}
+              className="px-3 py-1.5 text-sm bg-rose-600 text-white rounded hover:bg-rose-700"
+            >
+              Retry
+            </button>
+          </div>
+        )}
         resetKeys={[refreshKey]}
       >
         <RSCRoute componentName="LiveActivity" componentProps={{ simulateError, refreshKey }} />

--- a/client/app/bundles/server-components/components/LiveActivityRefresher.jsx
+++ b/client/app/bundles/server-components/components/LiveActivityRefresher.jsx
@@ -1,9 +1,27 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import RSCRoute from 'react-on-rails-pro/RSCRoute';
 import { useRSC } from 'react-on-rails-pro/RSCProvider';
+
+// Same shape and dimensions as the rendered LiveActivity card. Local Suspense
+// fallback prevents the RSCRoute suspension from bubbling to an outer
+// boundary, which would collapse the whole page during in-flight fetches.
+const ActivityCardSkeleton = () => (
+  <div className="bg-gradient-to-br from-indigo-50 to-purple-50 border border-indigo-200 rounded-xl p-5">
+    <div className="grid grid-cols-3 gap-4 text-sm">
+      {['Server Time', 'Free RAM', 'Uptime (hrs)'].map((label) => (
+        <div key={label}>
+          <div className="text-xs text-indigo-600 font-medium uppercase tracking-wide mb-1">
+            {label}
+          </div>
+          <div className="font-mono text-indigo-300 animate-pulse">—</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
 
 const LiveActivityRefresher = () => {
   const [refreshKey, setRefreshKey] = useState(0);
@@ -67,7 +85,9 @@ const LiveActivityRefresher = () => {
         )}
         resetKeys={[refreshKey]}
       >
-        <RSCRoute componentName="LiveActivity" componentProps={{ simulateError, refreshKey }} />
+        <Suspense fallback={<ActivityCardSkeleton />}>
+          <RSCRoute componentName="LiveActivity" componentProps={{ simulateError, refreshKey }} />
+        </Suspense>
       </ErrorBoundary>
     </div>
   );

--- a/client/app/bundles/server-components/components/LiveActivityRefresher.jsx
+++ b/client/app/bundles/server-components/components/LiveActivityRefresher.jsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import RSCRoute from 'react-on-rails-pro/RSCRoute';
+
+function ErrorFallback({ error, resetErrorBoundary }) {
+  return (
+    <div className="bg-rose-50 border border-rose-200 rounded-lg p-4">
+      <p className="text-rose-700 font-semibold mb-1">Server component fetch failed</p>
+      <p className="text-rose-600 text-sm font-mono mb-3">{error.message}</p>
+      <button
+        type="button"
+        onClick={resetErrorBoundary}
+        className="px-3 py-1.5 text-sm bg-rose-600 text-white rounded hover:bg-rose-700"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+const LiveActivityRefresher = () => {
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [simulateError, setSimulateError] = useState(false);
+
+  const handleRefresh = () => {
+    setSimulateError(false);
+    setRefreshKey((k) => k + 1);
+  };
+
+  const handleSimulateError = () => {
+    setSimulateError(true);
+    setRefreshKey((k) => k + 1);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleRefresh}
+          className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700"
+        >
+          Refresh
+        </button>
+        <button
+          type="button"
+          onClick={handleSimulateError}
+          className="px-3 py-1.5 text-sm bg-amber-100 text-amber-800 border border-amber-300 rounded hover:bg-amber-200"
+        >
+          Simulate Error
+        </button>
+        <span className="text-xs text-slate-500 ml-2">
+          Refresh count: {refreshKey}
+        </span>
+      </div>
+      <ErrorBoundary
+        FallbackComponent={ErrorFallback}
+        onReset={() => {
+          setSimulateError(false);
+          setRefreshKey((k) => k + 1);
+        }}
+        resetKeys={[refreshKey]}
+      >
+        <RSCRoute componentName="LiveActivity" componentProps={{ simulateError, refreshKey }} />
+      </ErrorBoundary>
+    </div>
+  );
+};
+
+export default LiveActivityRefresher;

--- a/client/app/bundles/server-components/components/ServerInfo.jsx
+++ b/client/app/bundles/server-components/components/ServerInfo.jsx
@@ -14,7 +14,6 @@ function ServerInfo() {
     totalMemory: (os.totalmem() / (1024 * 1024 * 1024)).toFixed(1),
     freeMemory: (os.freemem() / (1024 * 1024 * 1024)).toFixed(1),
     cpus: os.cpus().length,
-    hostname: os.hostname(),
   };
 
   // Using lodash on the server — this 70KB+ library stays server-side
@@ -29,7 +28,6 @@ function ServerInfo() {
     totalMemory: 'Total RAM (GB)',
     freeMemory: 'Free RAM (GB)',
     cpus: 'CPU Cores',
-    hostname: 'Hostname',
   };
 
   return (

--- a/client/app/bundles/server-components/components/ServerInfo.jsx
+++ b/client/app/bundles/server-components/components/ServerInfo.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import os from 'os';
 import _ from 'lodash';
 
-async function ServerInfo() {
+function ServerInfo() {
   const serverInfo = {
     platform: os.platform(),
     arch: os.arch(),

--- a/client/app/bundles/server-components/components/ServerInfo.jsx
+++ b/client/app/bundles/server-components/components/ServerInfo.jsx
@@ -1,0 +1,58 @@
+// Server Component - uses Node.js os module, which only exists on the server.
+// This component and its dependencies are never sent to the browser.
+
+import React from 'react';
+import os from 'os';
+import _ from 'lodash';
+
+async function ServerInfo() {
+  const serverInfo = {
+    platform: os.platform(),
+    arch: os.arch(),
+    nodeVersion: process.version,
+    uptime: Math.floor(os.uptime() / 3600),
+    totalMemory: (os.totalmem() / (1024 * 1024 * 1024)).toFixed(1),
+    freeMemory: (os.freemem() / (1024 * 1024 * 1024)).toFixed(1),
+    cpus: os.cpus().length,
+    hostname: os.hostname(),
+  };
+
+  // Using lodash on the server — this 70KB+ library stays server-side
+  const infoEntries = _.toPairs(serverInfo);
+  const grouped = _.chunk(infoEntries, 4);
+
+  const labels = {
+    platform: 'Platform',
+    arch: 'Architecture',
+    nodeVersion: 'Node.js',
+    uptime: 'Uptime (hrs)',
+    totalMemory: 'Total RAM (GB)',
+    freeMemory: 'Free RAM (GB)',
+    cpus: 'CPU Cores',
+    hostname: 'Hostname',
+  };
+
+  return (
+    <div className="bg-gradient-to-br from-emerald-50 to-teal-50 border border-emerald-200 rounded-xl p-6">
+      <p className="text-xs text-emerald-600 mb-4 font-medium">
+        This data comes from the Node.js <code className="bg-emerald-100 px-1 rounded">os</code> module
+        — it runs only on the server. The <code className="bg-emerald-100 px-1 rounded">lodash</code> library
+        used to format it never reaches the browser.
+      </p>
+      <div className="grid md:grid-cols-2 gap-x-8 gap-y-1">
+        {grouped.map((group) => (
+          <div key={group.map(([k]) => k).join('-')} className="space-y-1">
+            {group.map(([key, value]) => (
+              <div key={key} className="flex justify-between py-1.5 border-b border-emerald-100 last:border-0">
+                <span className="text-sm text-emerald-700 font-medium">{labels[key] || key}</span>
+                <span className="text-sm text-emerald-900 font-mono">{value}</span>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ServerInfo;

--- a/client/app/bundles/server-components/components/TogglePanel.jsx
+++ b/client/app/bundles/server-components/components/TogglePanel.jsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const TogglePanel = ({ title, children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="border border-slate-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="w-full flex items-center justify-between px-4 py-2.5 bg-slate-50 hover:bg-slate-100 transition-colors text-left"
+      >
+        <span className="text-sm font-medium text-slate-700">{title}</span>
+        <svg
+          className={`w-4 h-4 text-slate-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="px-4 py-3 bg-white">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+};
+
+TogglePanel.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default TogglePanel;

--- a/client/app/bundles/server-components/ror_components/LiveActivity.jsx
+++ b/client/app/bundles/server-components/ror_components/LiveActivity.jsx
@@ -6,10 +6,13 @@ async function LiveActivity({ simulateError = false }) {
     throw new Error('Simulated server-side render failure (demo)');
   }
 
-  // Small delay so the refresh-in-flight state is visible.
-  await new Promise((resolve) => {
-    setTimeout(resolve, 300);
-  });
+  // Opt-in delay so the refresh-in-flight state is visible in the demo.
+  // Matches the gate in CommentsFeed; off by default in production.
+  if (process.env.RSC_SUSPENSE_DEMO_DELAY === 'true') {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 300);
+    });
+  }
 
   const stats = {
     serverTime: new Date().toISOString(),

--- a/client/app/bundles/server-components/ror_components/LiveActivity.jsx
+++ b/client/app/bundles/server-components/ror_components/LiveActivity.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import os from 'os';
+
+async function LiveActivity({ simulateError = false }) {
+  if (simulateError) {
+    throw new Error('Simulated server-side render failure (demo)');
+  }
+
+  // Small delay so the refresh-in-flight state is visible.
+  await new Promise((resolve) => {
+    setTimeout(resolve, 300);
+  });
+
+  const stats = {
+    serverTime: new Date().toISOString(),
+    freeMemoryMB: Math.round(os.freemem() / (1024 * 1024)),
+    uptimeHours: Math.floor(os.uptime() / 3600),
+  };
+
+  return (
+    <div className="bg-gradient-to-br from-indigo-50 to-purple-50 border border-indigo-200 rounded-xl p-5">
+      <div className="grid grid-cols-3 gap-4 text-sm">
+        <div>
+          <div className="text-xs text-indigo-600 font-medium uppercase tracking-wide mb-1">
+            Server Time
+          </div>
+          <div className="font-mono text-indigo-900">{stats.serverTime}</div>
+        </div>
+        <div>
+          <div className="text-xs text-indigo-600 font-medium uppercase tracking-wide mb-1">
+            Free RAM
+          </div>
+          <div className="font-mono text-indigo-900">{stats.freeMemoryMB} MB</div>
+        </div>
+        <div>
+          <div className="text-xs text-indigo-600 font-medium uppercase tracking-wide mb-1">
+            Uptime (hrs)
+          </div>
+          <div className="font-mono text-indigo-900">{stats.uptimeHours}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default LiveActivity;

--- a/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
+++ b/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
@@ -6,6 +6,7 @@ import React, { Suspense } from 'react';
 import ServerInfo from '../components/ServerInfo';
 import CommentsFeed from '../components/CommentsFeed';
 import TogglePanel from '../components/TogglePanel';
+import LiveActivityRefresher from '../components/LiveActivityRefresher';
 
 const ServerComponentsPage = ({ comments = [] }) => {
   return (
@@ -57,6 +58,25 @@ const ServerComponentsPage = ({ comments = [] }) => {
           </TogglePanel>
         </section>
 
+        {/* Client-fetched server component via RSCRoute + ErrorBoundary */}
+        <section>
+          <h2 className="text-xl font-semibold text-slate-700 mb-4 flex items-center gap-2">
+            Live Server Activity
+            <span className="text-xs font-normal bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full">
+              RSCRoute + ErrorBoundary
+            </span>
+          </h2>
+          <p className="text-slate-500 text-sm mb-4">
+            Click <strong>Refresh</strong> to fetch a new RSC payload — the server re-renders
+            this section and streams the result back, no client-side JSON parsing or loading
+            state plumbing. Click <strong>Simulate Error</strong> to make the server component
+            throw; the failure surfaces as <code>ServerComponentFetchError</code> and is
+            caught by <code>&lt;ErrorBoundary&gt;</code>, which renders a Retry button that
+            re-fetches with corrected props.
+          </p>
+          <LiveActivityRefresher />
+        </section>
+
         {/* Async data fetching with Suspense streaming */}
         <section>
           <h2 className="text-xl font-semibold text-slate-700 mb-4 flex items-center gap-2">
@@ -66,8 +86,9 @@ const ServerComponentsPage = ({ comments = [] }) => {
             </span>
           </h2>
           <p className="text-slate-500 text-sm mb-4">
-            Comments are fetched directly on the server using the Rails API.
-            The page shell renders immediately while this section streams in progressively.
+            Comments come from the Rails controller as props — the canonical React on Rails Pro
+            pattern. The page shell renders immediately while this section streams in
+            progressively as Suspense boundaries resolve.
           </p>
           <Suspense
             fallback={

--- a/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
+++ b/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
@@ -72,7 +72,7 @@ const ServerComponentsPage = ({ comments = [] }) => {
             state plumbing. Click <strong>Simulate Error</strong> to make the server component
             throw; the failure surfaces as <code>ServerComponentFetchError</code> and is
             caught by <code>&lt;ErrorBoundary&gt;</code>, which renders a Retry button that
-            re-fetches with corrected props.
+            calls <code>refetchComponent</code> with corrected props.
           </p>
           <LiveActivityRefresher />
         </section>

--- a/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
+++ b/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
@@ -7,7 +7,7 @@ import ServerInfo from '../components/ServerInfo';
 import CommentsFeed from '../components/CommentsFeed';
 import TogglePanel from '../components/TogglePanel';
 
-const ServerComponentsPage = () => {
+const ServerComponentsPage = ({ comments = [] }) => {
   return (
     <div className="max-w-4xl mx-auto py-8 px-4">
       <header className="mb-10">
@@ -81,7 +81,7 @@ const ServerComponentsPage = () => {
               </div>
             }
           >
-            <CommentsFeed />
+            <CommentsFeed comments={comments} />
           </Suspense>
         </section>
 

--- a/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
+++ b/client/app/bundles/server-components/ror_components/ServerComponentsPage.jsx
@@ -3,9 +3,9 @@
 // None of these imports are shipped to the client bundle.
 
 import React, { Suspense } from 'react';
-import ServerInfo from './components/ServerInfo';
-import CommentsFeed from './components/CommentsFeed';
-import TogglePanel from './components/TogglePanel';
+import ServerInfo from '../components/ServerInfo';
+import CommentsFeed from '../components/CommentsFeed';
+import TogglePanel from '../components/TogglePanel';
 
 const ServerComponentsPage = () => {
   return (

--- a/client/app/packs/stimulus-bundle.js
+++ b/client/app/packs/stimulus-bundle.js
@@ -1,3 +1,5 @@
+'use client';
+
 import ReactOnRails from 'react-on-rails-pro';
 import 'jquery-ujs';
 import { Turbo } from '@hotwired/turbo-rails';

--- a/client/app/packs/stores-registration.js
+++ b/client/app/packs/stores-registration.js
@@ -1,3 +1,4 @@
+// 'use client' keeps this pack and its store imports out of the RSC bundle.
 'use client';
 
 import ReactOnRails from 'react-on-rails-pro';

--- a/client/app/packs/stores-registration.js
+++ b/client/app/packs/stores-registration.js
@@ -1,3 +1,5 @@
+'use client';
+
 import ReactOnRails from 'react-on-rails-pro';
 import routerCommentsStore from '../bundles/comments/store/routerCommentsStore';
 import commentsStore from '../bundles/comments/store/commentsStore';

--- a/config/initializers/react_on_rails_pro.rb
+++ b/config/initializers/react_on_rails_pro.rb
@@ -16,4 +16,8 @@ ReactOnRailsPro.configure do |config|
   # so a blank env var (.env.example ships with `RENDERER_PASSWORD=`)
   # falls back to the dev default, matching the JS side's `||`.
   config.renderer_password = ENV["RENDERER_PASSWORD"].presence || "local-dev-renderer-password"
+
+  config.enable_rsc_support = true
+  config.rsc_bundle_js_file = "rsc-bundle.js"
+  config.rsc_payload_generation_url_path = "rsc_payload/"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  rsc_payload_route
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   # Serve websocket cable requests in-process
   # mount ActionCable.server => '/cable'
 
   root "pages#index"
+  get "server-components", to: "pages#server_components"
 
   get "simple", to: "pages#simple"
   get "rescript", to: "pages#rescript"

--- a/config/webpack/clientWebpackConfig.js
+++ b/config/webpack/clientWebpackConfig.js
@@ -1,6 +1,9 @@
 // The source code including full typescript support is available at:
 // https://github.com/shakacode/react_on_rails_tutorial_with_ssr_and_hmr_fast_refresh/blob/master/config/webpack/clientWebpackConfig.js
 
+const path = require('path');
+const { config } = require('shakapacker');
+const { RSCWebpackPlugin } = require('react-on-rails-rsc/WebpackPlugin');
 const commonWebpackConfig = require('./commonWebpackConfig');
 const { getBundler } = require('./bundlerUtils');
 
@@ -21,6 +24,16 @@ const configureClient = () => {
   // error shows referring to window["webpackJsonp"]. That is because the
   // client config is going to try to load chunks.
   delete clientConfig.entry['server-bundle'];
+
+  const clientReferencesDir = path.resolve(config.source_path || 'client/app');
+  clientConfig.plugins.push(
+    new RSCWebpackPlugin({
+      isServer: false,
+      clientReferences: [
+        { directory: clientReferencesDir, recursive: true, include: /\.(js|ts|jsx|tsx)$/ },
+      ],
+    }),
+  );
 
   return clientConfig;
 };

--- a/config/webpack/rscWebpackConfig.js
+++ b/config/webpack/rscWebpackConfig.js
@@ -8,16 +8,29 @@ const configureRsc = () => {
   };
   rscConfig.entry = rscEntry;
 
-  // Runs before babel-loader (webpack loaders execute right-to-left) to
-  // detect 'use client' directives in raw source before transpilation.
+  // Runs before babel/swc (webpack loaders execute right-to-left) to detect
+  // 'use client' directives in raw source before transpilation. Shakapacker
+  // generates rule.use as an array for Babel and as a function for SWC, so
+  // handle both forms.
   const { rules } = rscConfig.module;
   rules.forEach((rule) => {
-    if (Array.isArray(rule.use)) {
-      const babelLoader = extractLoader(rule, 'babel-loader');
-      if (babelLoader) {
-        rule.use.push({
-          loader: 'react-on-rails-rsc/WebpackLoader',
-        });
+    if (typeof rule.use === 'function') {
+      const originalUse = rule.use;
+      rule.use = function rscLoaderWrapper(data) {
+        const result = originalUse.call(this, data);
+        const resultArray = Array.isArray(result) ? result : result ? [result] : [];
+        const resolvedRule = { use: resultArray };
+        const jsLoader =
+          extractLoader(resolvedRule, 'babel-loader') || extractLoader(resolvedRule, 'swc-loader');
+        if (jsLoader) {
+          return [...resultArray, { loader: 'react-on-rails-rsc/WebpackLoader' }];
+        }
+        return result;
+      };
+    } else if (Array.isArray(rule.use)) {
+      const jsLoader = extractLoader(rule, 'babel-loader') || extractLoader(rule, 'swc-loader');
+      if (jsLoader) {
+        rule.use = [...rule.use, { loader: 'react-on-rails-rsc/WebpackLoader' }];
       }
     }
   });

--- a/config/webpack/rscWebpackConfig.js
+++ b/config/webpack/rscWebpackConfig.js
@@ -1,0 +1,40 @@
+const { default: serverWebpackConfig, extractLoader } = require('./serverWebpackConfig');
+
+const configureRsc = () => {
+  const rscConfig = serverWebpackConfig(true);
+
+  const rscEntry = {
+    'rsc-bundle': rscConfig.entry['server-bundle'],
+  };
+  rscConfig.entry = rscEntry;
+
+  // Runs before babel-loader (webpack loaders execute right-to-left) to
+  // detect 'use client' directives in raw source before transpilation.
+  const { rules } = rscConfig.module;
+  rules.forEach((rule) => {
+    if (Array.isArray(rule.use)) {
+      const babelLoader = extractLoader(rule, 'babel-loader');
+      if (babelLoader) {
+        rule.use.push({
+          loader: 'react-on-rails-rsc/WebpackLoader',
+        });
+      }
+    }
+  });
+
+  rscConfig.resolve = {
+    ...rscConfig.resolve,
+    conditionNames: ['react-server', '...'],
+    alias: {
+      ...rscConfig.resolve?.alias,
+      // RSC payload generation doesn't need react-dom/server; importing
+      // it in the react-server environment causes a runtime error.
+      'react-dom/server': false,
+    },
+  };
+
+  rscConfig.output.filename = 'rsc-bundle.js';
+  return rscConfig;
+};
+
+module.exports = configureRsc;

--- a/config/webpack/webpackConfig.js
+++ b/config/webpack/webpackConfig.js
@@ -3,6 +3,7 @@
 
 const clientWebpackConfig = require('./clientWebpackConfig');
 const { default: serverWebpackConfig } = require('./serverWebpackConfig');
+const rscWebpackConfig = require('./rscWebpackConfig');
 
 const webpackConfig = (envSpecific) => {
   const clientConfig = clientWebpackConfig();
@@ -22,6 +23,10 @@ const webpackConfig = (envSpecific) => {
     // eslint-disable-next-line no-console
     console.log('[React on Rails] Creating only the server bundle.');
     result = serverConfig;
+  } else if (process.env.RSC_BUNDLE_ONLY) {
+    // eslint-disable-next-line no-console
+    console.log('[React on Rails] Creating only the RSC bundle.');
+    result = rscWebpackConfig();
   } else {
     // default is the standard client and server build
     // eslint-disable-next-line no-console

--- a/config/webpack/webpackConfig.js
+++ b/config/webpack/webpackConfig.js
@@ -28,10 +28,9 @@ const webpackConfig = (envSpecific) => {
     console.log('[React on Rails] Creating only the RSC bundle.');
     result = rscWebpackConfig();
   } else {
-    // default is the standard client and server build
     // eslint-disable-next-line no-console
-    console.log('[React on Rails] Creating both client and server bundles.');
-    result = [clientConfig, serverConfig];
+    console.log('[React on Rails] Creating client, server, and RSC bundles.');
+    result = [clientConfig, serverConfig, rscWebpackConfig()];
   }
 
   // To debug, uncomment next line and inspect "result"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "prop-types": "^15.8.1",
     "react": "~19.0.4",
     "react-dom": "~19.0.4",
+    "react-error-boundary": "^4.1.2",
     "react-intl": "^6.4.4",
     "react-on-rails-pro": "16.6.0",
     "react-on-rails-pro-node-renderer": "16.6.0",

--- a/renderer/node-renderer.js
+++ b/renderer/node-renderer.js
@@ -41,6 +41,12 @@ const config = {
   // deps rely on during SSR. Without URL, react-router-dom's NavLink throws
   // `ReferenceError: URL is not defined` via encodeLocation.
   additionalContext: { URL, AbortController },
+  // RSC requires a real setTimeout. The renderer's default stubTimers:true
+  // replaces setTimeout with a no-op to prevent legacy SSR from leaking
+  // timers, but React's RSC server renderer uses setTimeout internally for
+  // Flight-protocol yielding — with it stubbed, the RSC stream silently
+  // emits zero chunks and hangs until the Fastify idle timeout fires.
+  stubTimers: false,
 };
 
 reactOnRailsProNodeRenderer(config);

--- a/renderer/node-renderer.js
+++ b/renderer/node-renderer.js
@@ -47,6 +47,11 @@ const config = {
   // Flight-protocol yielding — with it stubbed, the RSC stream silently
   // emits zero chunks and hangs until the Fastify idle timeout fires.
   stubTimers: false,
+  // Surface console output from async server-component code. Without this,
+  // `console.error` calls from within async Server Components (e.g.
+  // CommentsFeed's catch block) are silently dropped by the VM, making
+  // runtime failures in RSC components invisible.
+  replayServerAsyncOperationLogs: true,
 };
 
 reactOnRailsProNodeRenderer(config);

--- a/spec/requests/server_components_spec.rb
+++ b/spec/requests/server_components_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Server Components" do
+  it "GET /server-components returns the demo page shell" do
+    get "/server-components"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("React Server Components Demo")
+  end
+
+  describe "RSC payload endpoint" do
+    def parsed_chunks
+      response.body.each_line.filter_map do |line|
+        stripped = line.strip
+        next if stripped.empty?
+
+        JSON.parse(stripped)
+      end
+    end
+
+    def expect_valid_rsc_payload
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("application/x-ndjson")
+      chunks = parsed_chunks
+      expect(chunks).not_to be_empty
+      expect(chunks.any? { |chunk| chunk.key?("html") }).to be(true)
+    end
+
+    it "streams a valid RSC payload for ServerComponentsPage" do
+      get "/rsc_payload/ServerComponentsPage", params: { props: "{}" }
+      expect_valid_rsc_payload
+    end
+
+    it "streams a valid RSC payload for LiveActivity" do
+      get "/rsc_payload/LiveActivity", params: { props: "{}" }
+      expect_valid_rsc_payload
+    end
+  end
+end

--- a/spec/requests/server_components_spec.rb
+++ b/spec/requests/server_components_spec.rb
@@ -32,6 +32,15 @@ describe "Server Components" do
       expect_valid_rsc_payload
     end
 
+    it "streams a valid RSC payload for ServerComponentsPage with populated comments" do
+      now = 1.minute.ago.iso8601
+      comments = [
+        { id: 1, author: "Alice", text: "Hello **markdown**", created_at: now, updated_at: now },
+      ]
+      get "/rsc_payload/ServerComponentsPage", params: { props: { comments: comments }.to_json }
+      expect_valid_rsc_payload
+    end
+
     it "streams a valid RSC payload for LiveActivity" do
       get "/rsc_payload/LiveActivity", params: { props: "{}" }
       expect_valid_rsc_payload

--- a/spec/system/server_components_demo_spec.rb
+++ b/spec/system/server_components_demo_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Server Components demo" do
+  before { visit "/server-components" }
+
+  it "renders the four demo sections" do
+    expect(page).to have_selector("h2", text: "Server Environment")
+    expect(page).to have_selector("h2", text: "Interactive Client Component")
+    expect(page).to have_selector("h2", text: "Live Server Activity")
+    expect(page).to have_selector("h2", text: "Streamed Comments")
+  end
+
+  it "shows server-side data in ServerInfo" do
+    expect(page).to have_content("Platform")
+    expect(page).to have_content("Architecture")
+    expect(page).to have_content("Node.js")
+    expect(page).to have_content("CPU Cores")
+  end
+
+  describe "Live Server Activity (RSCRoute)" do
+    it "shows the initial activity card with the live stats labels" do
+      expect(page).to have_content("SERVER TIME")
+      expect(page).to have_content("FREE RAM")
+      expect(page).to have_content("UPTIME (HRS)")
+      expect(page).to have_content("Refresh count: 0")
+    end
+
+    it "updates content when Refresh is clicked" do
+      click_button "Refresh"
+      expect(page).to have_content("Refresh count: 1")
+    end
+
+    it "shows the ErrorBoundary fallback when Simulate Error is clicked, then recovers on Retry" do
+      click_button "Simulate Error"
+      expect(page).to have_content("Server component fetch failed")
+
+      click_button "Retry"
+      expect(page).to have_content("SERVER TIME")
+      expect(page).to have_no_content("Server component fetch failed")
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -8745,6 +8745,13 @@ react-dom@~19.0.4:
   dependencies:
     scheduler "^0.25.0"
 
+react-error-boundary@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.1.2.tgz#bc750ad962edb8b135d6ae922c046051eb58f289"
+  integrity sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-intl@^6.4.4:
   version "6.8.9"
   resolved "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz"


### PR DESCRIPTION
# Pro RSC migration 3/3: React Server Components demo

Adds a [React Server Components](https://www.reactonrails.com/docs/pro/react-server-components/how-react-server-components-work) demo page at `/server-components`, riding on top of [Sub-PR 2](https://github.com/shakacode/react-webpack-rails-tutorial/pull/728)'s NodeRenderer + webpack setup. Final sub-PR of the [Pro RSC migration](https://github.com/shakacode/react-webpack-rails-tutorial/pull/727); targets [`ihabadham/feature/pro-rsc/base`](https://github.com/shakacode/react-webpack-rails-tutorial/tree/ihabadham/feature/pro-rsc/base), not `master`.

## Demo

| Section | What it shows |
|---------|---------------|
| Server Environment | Server-only Node APIs (`os`, [`lodash`](https://www.npmjs.com/package/lodash)) used to render a panel — none of those deps reach the browser. |
| Interactive Client Component | A [`'use client'`](https://www.reactonrails.com/docs/migrating/rsc-preparing-app) Client Component nested inside a Server-Component tree, hydrated normally. |
| Live Server Activity | Client-driven server-component re-fetching with [`react-error-boundary`](https://www.npmjs.com/package/react-error-boundary) catching simulated errors and a Retry button that re-primes the cache before resetting the boundary. |
| Streamed Comments | Async Server Component receiving comments as props from the controller per the [canonical Pro data-fetching pattern](https://www.reactonrails.com/docs/migrating/rsc-data-fetching), streaming in via [`<Suspense>`](https://www.reactonrails.com/docs/migrating/rsc-component-patterns) after the page shell. |

## Verified

Deployed to the controlplane review app. All four sections render, RSC payloads stream, the Refresh / Simulate Error / Retry flow works end-to-end without page-shift artifacts. Covered by request + system specs (`spec/requests/server_components_spec.rb`, `spec/system/server_components_demo_spec.rb`).

## Stack context

- [Sub-PR 1 (#726)](https://github.com/shakacode/react-webpack-rails-tutorial/pull/726): gem + npm migration to `react_on_rails_pro` (merged).
- [Sub-PR 2 (#728)](https://github.com/shakacode/react-webpack-rails-tutorial/pull/728): NodeRenderer + webpack + deploy infra (merged).
- **Sub-PR 3 (this PR):** RSC demo.
- [Base PR (#727)](https://github.com/shakacode/react-webpack-rails-tutorial/pull/727) → `master`: consolidates all three sub-PRs; gets README + CLAUDE.md updates.
- Post-merge follow-up: switch `config/shakapacker.yml` back to rspack once [shakacode/react_on_rails_rsc#29](https://github.com/shakacode/react_on_rails_rsc/pull/29) ships.

## References

- Pro RSC docs: [Preparing your app](https://www.reactonrails.com/docs/migrating/rsc-preparing-app), [Component patterns](https://www.reactonrails.com/docs/migrating/rsc-component-patterns), [Data fetching](https://www.reactonrails.com/docs/migrating/rsc-data-fetching), [How RSC works](https://www.reactonrails.com/docs/pro/react-server-components/how-react-server-components-work).
- Reference setup: [Pro dummy app's `rscWebpackConfig.js`](https://github.com/shakacode/react_on_rails/blob/main/react_on_rails_pro/spec/dummy/config/webpack/rscWebpackConfig.js).
