### PR TITLE
Regenerate cpflow GitHub Actions

### DIFF
--- a/.github/actions/cpflow-build-docker-image/action.yml
+++ b/.github/actions/cpflow-build-docker-image/action.yml
@@ -52,7 +52,7 @@ runs:
         chmod 700 ~/.ssh
 
         if [[ -n "${DOCKER_BUILD_SSH_KNOWN_HOSTS}" ]]; then
-          printf '%s\n' "${DOCKER_BUILD_SSH_KNOWN_HOSTS}" | tr -d '\r' > ~/.ssh/known_hosts
+          printf '%s\n' "${DOCKER_BUILD_SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
         else
           printf '%s\n' \
             'github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl' \
@@ -62,7 +62,7 @@ runs:
         fi
         chmod 600 ~/.ssh/known_hosts
 
-        printf '%s\n' "${DOCKER_BUILD_SSH_KEY}" | tr -d '\r' > ~/.ssh/cpflow_build_key
+        printf '%s\n' "${DOCKER_BUILD_SSH_KEY}" > ~/.ssh/cpflow_build_key
         chmod 600 ~/.ssh/cpflow_build_key
 
     - name: Build Docker image

--- a/.github/actions/cpflow-setup-environment/action.yml
+++ b/.github/actions/cpflow-setup-environment/action.yml
@@ -14,16 +14,22 @@ inputs:
       from .ruby-version, .tool-versions, or the Gemfile.
     required: false
     default: ""
+  # GitHub parses double-brace expression snippets inside action metadata (including
+  # `description:`) while loading the composite action, and the `vars` context is not
+  # available in that phase. Keep these descriptions in plain prose - reference repo
+  # variables by NAME only, never with literal GitHub Actions expression syntax.
   cpln_cli_version:
     description: >-
-      @controlplane/cli version. Empty string falls back to the action's pinned default
-      so callers can pass `${{ vars.CPLN_CLI_VERSION }}` unconditionally.
+      @controlplane/cli version. Empty string falls back to the action's pinned default,
+      so callers can wire this input to the CPLN_CLI_VERSION repository variable
+      unconditionally.
     required: false
     default: ""
   cpflow_version:
     description: >-
-      cpflow gem version. Empty string falls back to the action's pinned default
-      so callers can pass `${{ vars.CPFLOW_VERSION }}` unconditionally.
+      cpflow gem version. Empty string falls back to the action's pinned default,
+      so callers can wire this input to the CPFLOW_VERSION repository variable
+      unconditionally.
     required: false
     default: ""
 

--- a/.github/actions/cpflow-wait-for-health/action.yml
+++ b/.github/actions/cpflow-wait-for-health/action.yml
@@ -61,15 +61,12 @@ runs:
         for attempt in $(seq 1 "${CPFLOW_MAX_RETRIES}"); do
           echo "Health check attempt ${attempt}/${CPFLOW_MAX_RETRIES}"
 
-          workload_stderr="$(mktemp)"
-          if ! workload_json="$(cpln workload get "${CPFLOW_WORKLOAD_NAME}" --gvc "${CPFLOW_APP_NAME}" --org "${CPFLOW_ORG}" -o json 2>"${workload_stderr}")"; then
+          if ! workload_json="$(cpln workload get "${CPFLOW_WORKLOAD_NAME}" --gvc "${CPFLOW_APP_NAME}" --org "${CPFLOW_ORG}" -o json 2>&1)"; then
             echo "::error::Workload '${CPFLOW_WORKLOAD_NAME}' not found in GVC '${CPFLOW_APP_NAME}'. Set PRIMARY_WORKLOAD to the correct workload name." >&2
-            cat "${workload_stderr}" >&2
-            rm -f "${workload_stderr}"
+            printf '%s\n' "${workload_json}" >&2
             echo "healthy=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-          rm -f "${workload_stderr}"
 
           endpoint="$(echo "${workload_json}" | jq -r '.status.endpoint // empty')"
           if [[ -n "${endpoint}" ]]; then

--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -113,13 +113,18 @@ jobs:
           cpln_org: ${{ vars.CPLN_ORG_STAGING }}
           review_app_prefix: ${{ vars.REVIEW_APP_PREFIX }}
 
+      # Finalizer still runs after delete failures, but only after config validation
+      # created the initial PR comment and workflow link env vars it updates.
       - name: Finalize delete status
         if: always() && steps.config.outputs.ready == 'true'
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
-            const success = "${{ job.status }}" === "success";
+            const commentId = Number(process.env.COMMENT_ID);
+            const success = process.env.JOB_STATUS === "success";
             const body = success
               ? [
                   `✅ Review app for PR #${process.env.PR_NUMBER} is deleted`,

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -119,11 +119,9 @@ jobs:
             same_repo="true"
           fi
 
-          {
-            echo "PR_NUMBER=$pr_number"
-            echo "APP_NAME=${REVIEW_APP_PREFIX}-$pr_number"
-            echo "PR_SHA=$pr_sha"
-          } >> "$GITHUB_ENV"
+          echo "PR_NUMBER=$pr_number" >> "$GITHUB_ENV"
+          echo "APP_NAME=${REVIEW_APP_PREFIX}-$pr_number" >> "$GITHUB_ENV"
+          echo "PR_SHA=$pr_sha" >> "$GITHUB_ENV"
           echo "same_repo=${same_repo}" >> "$GITHUB_OUTPUT"
 
       - name: Validate review app deployment source
@@ -305,9 +303,11 @@ jobs:
       - name: Update PR comment with build status
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
+            const commentId = Number(process.env.COMMENT_ID);
             if (!Number.isFinite(commentId) || commentId <= 0) {
               core.warning("Skipping PR comment update because no comment id was created.");
               return;
@@ -344,9 +344,11 @@ jobs:
       - name: Update PR comment with deploy status
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
+            const commentId = Number(process.env.COMMENT_ID);
             if (!Number.isFinite(commentId) || commentId <= 0) {
               core.warning("Skipping PR comment update because no comment id was created.");
               return;
@@ -398,12 +400,17 @@ jobs:
       - name: Finalize deployment status
         if: always() && steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
+          DEPLOYMENT_ID: ${{ steps.init-deployment.outputs.result }}
+          APP_URL: ${{ steps.workload.outputs.workload_url }}
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
-            const deploymentId = "${{ steps.init-deployment.outputs.result }}";
-            const appUrl = "${{ steps.workload.outputs.workload_url }}";
-            const success = "${{ job.status }}" === "success";
+            const commentId = Number(process.env.COMMENT_ID);
+            const deploymentId = process.env.DEPLOYMENT_ID;
+            const appUrl = process.env.APP_URL;
+            const success = process.env.JOB_STATUS === "success";
 
             if (deploymentId) {
               await github.rest.repos.createDeploymentStatus({

--- a/.github/workflows/cpflow-deploy-staging.yml
+++ b/.github/workflows/cpflow-deploy-staging.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Checkout repository
         if: steps.check-branch.outputs.is_deployable == 'true'
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate required secrets and variables
         if: steps.check-branch.outputs.is_deployable == 'true'

--- a/.github/workflows/cpflow-review-app-help.yml
+++ b/.github/workflows/cpflow-review-app-help.yml
@@ -28,13 +28,11 @@ jobs:
             const body = [
               "# Review app commands",
               "",
-              "Repo owners, members, and collaborators can use these commands:",
-              "",
               "- `+review-app-deploy` - create or redeploy this PR's review app.",
               "- `+review-app-delete` - delete this PR's review app and temporary resources.",
               "- `+review-app-help` - show setup details and workflow behavior.",
               "",
-              "For setup details, repo owners, members, and collaborators can comment `+review-app-help`."
+              "For setup details, comment `+review-app-help`."
             ].join("\n");
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
Regenerates the cpflow GitHub Actions templates from shakacode/control-plane-flow#297 so the composite action metadata no longer contains literal GitHub expression examples in input descriptions.

Why this needs to land on `master`: the review-app deploy workflow checks out `github.event.repository.default_branch` for trusted local composite actions before passing Control Plane secrets. PR branches can contain the fix, but the runner still loads `.github/actions/cpflow-setup-environment/action.yml` from `master`.

Validation run locally:
- parsed all `.github/actions/**/action.yml` and `.github/workflows/*.yml` with Ruby YAML
- verified no action input descriptions contain `${{`
- `actionlint -ignore 'SC2129' .github/workflows/cpflow-*.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/CD workflows and composite actions used for deploy/delete flows (including secret-adjacent steps), so misconfiguration could break deployments or PR comment updates, though logic changes are small and mostly around quoting/variable handling.
> 
> **Overview**
> Regenerates the cpflow composite actions/workflows to **remove literal `${{ ... }}` examples from action input descriptions**, preventing GitHub from trying to evaluate expressions while loading action metadata.
> 
> Tightens and simplifies several workflow steps: switches `github-script` steps to read dynamic values (e.g., comment/deployment IDs and job status) via `env` instead of inline expressions, adds `persist-credentials: false` to additional checkouts, and streamlines shell env exports.
> 
> Minor behavior tweaks include adjusting SSH key/known_hosts file writes in `cpflow-build-docker-image`, improving error capture in `cpflow-wait-for-health` (merge stderr into captured output), and slightly simplifying the review-app help message copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89bcf9aa5026d55b56156e2777352b9e3bf3a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflows and composite actions for improved reliability and consistency in CI/CD pipelines, including refined SSH key handling, error output management, and environment variable passing.
  * Simplified help documentation for review app commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-webpack-rails-tutorial/pull/736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->