### PR TITLE
Persist CPLN token for cpflow steps

### DIFF
--- a/.github/actions/cpflow-setup-environment/action.yml
+++ b/.github/actions/cpflow-setup-environment/action.yml
@@ -96,6 +96,12 @@ runs:
           exit 1
         fi
 
+        # Keep the service-account token available to later cpflow/cpln steps.
+        # The profile stores org/default metadata, but cpflow direct API calls
+        # read CPLN_TOKEN before falling back to `cpln profile token`.
+        echo "::add-mask::${CPLN_TOKEN}"
+        printf 'CPLN_TOKEN=%s\n' "${CPLN_TOKEN}" >> "${GITHUB_ENV}"
+
         # `cpln profile update` lists `create` as an alias (cpln profile --help) and is
         # idempotent: it creates the profile if missing and updates it otherwise. Calling
         # update directly avoids parsing the CLI's "already exists" English error text,


### PR DESCRIPTION
## Summary

- Persist the Control Plane service-account token from the setup action into `$GITHUB_ENV`.
- Mask the token before exporting it so later `cpflow` and `cpln` steps can authenticate without exposing it.

## Why

After #736, the review-app deploy gets past setup but fails in `Check if review app exists` with:

```text
ERROR: Unknown API token format. Please re-run 'cpln profile login' or set the correct CPLN_TOKEN env variable.
```

That step runs `cpflow exists`, which uses direct Control Plane API calls and reads `CPLN_TOKEN` before falling back to `cpln profile token`. The setup action already receives the token, but it was only scoped to the setup shell step, so later workflow steps did not inherit it.

## Verification

- `bin/conductor-exec ruby -e 'contents = File.read(".github/actions/cpflow-setup-environment/action.yml"); abort "setup action does not persist CPLN_TOKEN to GITHUB_ENV" unless contents.include?("GITHUB_ENV") && contents.match?(/CPLN_TOKEN=.*GITHUB_ENV|GITHUB_ENV.*CPLN_TOKEN/m); puts "setup action persists CPLN_TOKEN"'`
- `bin/conductor-exec ruby -e 'require "yaml"; Dir[".github/actions/**/action.yml", ".github/workflows/*.yml"].sort.each { |path| YAML.load_file(path, aliases: true); puts "parsed #{path}" }'`
- `bin/conductor-exec ruby -e 'require "yaml"; bad=[]; Dir[".github/actions/**/action.yml"].sort.each do |path| doc=YAML.load_file(path, aliases: true); doc.fetch("inputs", {}).each do |name, spec| bad << "#{path}:#{name}" if spec["description"].to_s.include?("${{"); end; end; abort bad.join("\n") unless bad.empty?; puts "no action metadata descriptions contain GitHub expressions"'`
- `bin/conductor-exec actionlint -ignore 'SC2129' .github/workflows/cpflow-*.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions secret handling by exporting `CPLN_TOKEN` into `GITHUB_ENV`; masking reduces log exposure but incorrect usage could still leak credentials or affect downstream authentication.
> 
> **Overview**
> Ensures subsequent workflow steps can authenticate with Control Plane by **persisting `CPLN_TOKEN` beyond the setup step**.
> 
> The `cpflow-setup-environment` composite action now masks the service-account token and writes it to `GITHUB_ENV`, so later `cpflow`/`cpln` commands that rely on `CPLN_TOKEN` can use it without requiring a separate login step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec7a5845a1d7c87941e0e6a5173cb22f69a63597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Control Plane token handling in CI/CD workflows to improve reliability of automated deployments across pipeline steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-webpack-rails-tutorial/pull/738?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->