### PR TITLE
[codex] Document Conductor command wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,55 @@ React on Rails demo app — a Rails application with React, Redux, Tailwind CSS,
 
 - `prompts/`: shared prompt templates for Codex, GPT, and other non-Claude tools
 
+## Build and Test Commands
+
+```bash
+# Run development server
+bin/dev
+
+# Run tests
+bundle exec rspec
+
+# Run linting
+bundle exec rubocop
+
+# Auto-fix linting issues
+bundle exec rubocop -a
+```
+
 ## Working Rules
 
 - When the user asks to address PR review comments, follow `prompts/address-review.md`.
+- Run Ruby, Bundler, Node, pnpm, and git hook-sensitive commands through `bin/conductor-exec` so non-interactive shells use the project tool versions.
+
+## Conductor Compatibility
+
+Conductor runs commands in a non-interactive shell that does not source `.zshrc`.
+That means version manager shell hooks, such as mise PATH reordering from `.tool-versions`,
+may not run. Commands can accidentally use system Ruby or Node instead of the project versions.
+
+Symptoms include:
+
+- `ruby --version` returns system Ruby instead of the project Ruby.
+- Pre-commit hooks fail with the wrong tool versions.
+- `bundle` commands fail due to incompatible Ruby versions.
+- Node or pnpm commands use the wrong Node version.
+
+Use the wrapper for commands that depend on project tool versions:
+
+```bash
+# Instead of:
+ruby --version
+bundle exec rubocop
+pnpm install
+git commit -m "message"
+
+# Use:
+bin/conductor-exec ruby --version
+bin/conductor-exec bundle exec rubocop
+bin/conductor-exec pnpm install
+bin/conductor-exec git commit -m "message"
+```
+
+The wrapper uses `mise exec` when mise is available and falls back to direct execution
+for non-mise users.


### PR DESCRIPTION
## Summary

- Adds the project build/test command reference to `AGENTS.md`.
- Documents why Conductor needs `bin/conductor-exec` for version-managed Ruby, Bundler, Node, pnpm, and git hook-sensitive commands.
- Preserves the existing repo overview and address-review guidance already on `master`.

## Validation

- `git diff --check`

## Notes

I intentionally left the incidental JS formatting-only edits and the stale staged homepage/control-plane diffs out of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to `AGENTS.md`; no runtime code paths are modified. Risk is limited to potential developer confusion if instructions are incorrect.
> 
> **Overview**
> Adds a **build/test command quick reference** to `AGENTS.md` (dev server, RSpec, RuboCop, and auto-fix).
> 
> Documents *Conductor non-interactive shell pitfalls* and standardizes guidance to run Ruby/Bundler/Node/pnpm and git-hook-sensitive commands via `bin/conductor-exec`, including example before/after command invocations and a note about `mise exec` fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a31b4298e254ee1d64ee10f67b9d5d2258445a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive build and test command documentation for common development tasks
* Expanded developer guidance for running project-specific commands to maintain environment consistency
* Introduced compatibility information for development workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-webpack-rails-tutorial/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->