### PR TITLE
Pin cpflow workflows to Ruby setup fallback

### DIFF
--- a/.github/workflows/cpflow-cleanup-stale-review-apps.yml
+++ b/.github/workflows/cpflow-cleanup-stale-review-apps.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   cleanup:
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-cleanup-stale-review-apps.yml@8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-cleanup-stale-review-apps.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     with:
-      control_plane_flow_ref: 8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     secrets: inherit

--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -26,7 +26,7 @@ jobs:
        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_target' && github.event.action == 'closed') ||
       github.event_name == 'workflow_dispatch'
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-delete-review-app.yml@8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-delete-review-app.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     with:
-      control_plane_flow_ref: 8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     secrets: inherit

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -30,7 +30,7 @@ jobs:
        github.event.issue.pull_request &&
        contains(fromJson('["+review-app-deploy","+review-app-deploy\n","+review-app-deploy\r\n"]'), github.event.comment.body) &&
        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-review-app.yml@8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-review-app.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     with:
-      control_plane_flow_ref: 8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     secrets: inherit

--- a/.github/workflows/cpflow-deploy-staging.yml
+++ b/.github/workflows/cpflow-deploy-staging.yml
@@ -16,8 +16,8 @@ permissions:
 
 jobs:
   deploy-staging:
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-staging.yml@8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-staging.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     with:
-      control_plane_flow_ref: 8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
       staging_app_branch_default: ""
     secrets: inherit

--- a/.github/workflows/cpflow-help-command.yml
+++ b/.github/workflows/cpflow-help-command.yml
@@ -23,4 +23,4 @@ jobs:
        contains(fromJson('["+review-app-help","+review-app-help\n","+review-app-help\r\n"]'), github.event.comment.body) &&
        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       github.event_name == 'workflow_dispatch'
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-help-command.yml@8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-help-command.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0

--- a/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   promote-to-production:
     if: github.event.inputs.confirm_promotion == 'promote'
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-promote-staging-to-production.yml@8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-promote-staging-to-production.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     with:
-      control_plane_flow_ref: 8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
     secrets: inherit

--- a/.github/workflows/cpflow-review-app-help.yml
+++ b/.github/workflows/cpflow-review-app-help.yml
@@ -15,4 +15,4 @@ permissions:
 jobs:
   show-help:
     if: vars.REVIEW_APP_PREFIX != ''
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-review-app-help.yml@8e9c0c5e9991ac8651ae2721830bf5231f34de5c
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-review-app-help.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0


### PR DESCRIPTION
## Summary
- repin generated cpflow workflow wrappers from upstream commit 8e9c0c5 to 6f44c840
- picks up the cpflow-setup-environment Ruby fallback fix from control-plane-flow PR 306
- intended to fix the post-merge staging deploy failure in Setup environment

## Verification
- bin/test-cpflow-github-flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes which upstream reusable GitHub Actions workflows are referenced, but it can affect deploy/review-app automation behavior if the new pinned ref has regressions.
> 
> **Overview**
> Repins all `cpflow-*` GitHub Actions workflow wrappers to a newer pinned `shakacode/control-plane-flow` commit (`6f44c840…`), updating both the `uses:` refs and matching `control_plane_flow_ref` inputs.
> 
> This affects the reusable workflows for **staging deploy**, **review app deploy/delete/help**, **stale review app cleanup**, and **staging promotion**, and is intended to pick up the upstream environment-setup (Ruby fallback) fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3544e89c14dc5e21381b4bd11333807bd31f3aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment and review app management workflows to use the latest versions of shared infrastructure tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-webpack-rails-tutorial/pull/742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->