### PR TITLE
Pin cpflow delete checkout fix

### DIFF
--- a/.github/workflows/cpflow-cleanup-stale-review-apps.yml
+++ b/.github/workflows/cpflow-cleanup-stale-review-apps.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   cleanup:
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-cleanup-stale-review-apps.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-cleanup-stale-review-apps.yml@3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     with:
-      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+      control_plane_flow_ref: 3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     secrets: inherit

--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -26,7 +26,7 @@ jobs:
        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       (github.event_name == 'pull_request_target' && github.event.action == 'closed') ||
       github.event_name == 'workflow_dispatch'
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-delete-review-app.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-delete-review-app.yml@3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     with:
-      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+      control_plane_flow_ref: 3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     secrets: inherit

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -30,7 +30,7 @@ jobs:
        github.event.issue.pull_request &&
        contains(fromJson('["+review-app-deploy","+review-app-deploy\n","+review-app-deploy\r\n"]'), github.event.comment.body) &&
        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-review-app.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-review-app.yml@3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     with:
-      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+      control_plane_flow_ref: 3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     secrets: inherit

--- a/.github/workflows/cpflow-deploy-staging.yml
+++ b/.github/workflows/cpflow-deploy-staging.yml
@@ -16,8 +16,8 @@ permissions:
 
 jobs:
   deploy-staging:
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-staging.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-deploy-staging.yml@3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     with:
-      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+      control_plane_flow_ref: 3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
       staging_app_branch_default: ""
     secrets: inherit

--- a/.github/workflows/cpflow-help-command.yml
+++ b/.github/workflows/cpflow-help-command.yml
@@ -23,4 +23,4 @@ jobs:
        contains(fromJson('["+review-app-help","+review-app-help\n","+review-app-help\r\n"]'), github.event.comment.body) &&
        contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
       github.event_name == 'workflow_dispatch'
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-help-command.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-help-command.yml@3e0e7e1f0a35c15648cc9254b573b058d77ca8c4

--- a/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   promote-to-production:
     if: github.event.inputs.confirm_promotion == 'promote'
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-promote-staging-to-production.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-promote-staging-to-production.yml@3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     with:
-      control_plane_flow_ref: 6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+      control_plane_flow_ref: 3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
     secrets: inherit

--- a/.github/workflows/cpflow-review-app-help.yml
+++ b/.github/workflows/cpflow-review-app-help.yml
@@ -15,4 +15,4 @@ permissions:
 jobs:
   show-help:
     if: vars.REVIEW_APP_PREFIX != ''
-    uses: shakacode/control-plane-flow/.github/workflows/cpflow-review-app-help.yml@6f44c84049d4fa09aaa8c0a72cc436cd52e66fb0
+    uses: shakacode/control-plane-flow/.github/workflows/cpflow-review-app-help.yml@3e0e7e1f0a35c15648cc9254b573b058d77ca8c4


### PR DESCRIPTION
## Summary
- repin generated cpflow reusable workflow wrappers to upstream control-plane-flow commit 3e0e7e1f0a35c15648cc9254b573b058d77ca8c4
- picks up shakacode/control-plane-flow#307 so review-app deletion checks out the downstream project before running cpflow delete

## Validation
- bin/test-cpflow-github-flow
- bin/conductor-exec git diff --check

This is needed because closing #734 exposed that the delete reusable workflow could not find .controlplane/controlplane.yml while cleaning up the old review app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates pinned SHAs for reusable `control-plane-flow` GitHub Actions workflows that manage deploy/delete/cleanup of review and staging apps; any upstream workflow behavior changes could impact automation and environment lifecycle operations.
> 
> **Overview**
> Repins all cpflow GitHub Actions workflow wrappers (`deploy-review-app`, `delete-review-app`, `cleanup-stale-review-apps`, `deploy-staging`, `promote-staging-to-production`, and help workflows) from commit `6f44c84...` to `3e0e7e1...`, including updating the `control_plane_flow_ref` inputs where present.
> 
> This pulls in upstream reusable-workflow changes (notably for review-app deletion) without changing local workflow logic beyond the pinned references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e48f0b0b2e4021888e036cae57ebd382da9f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation workflow infrastructure across review app, staging, and production environments to use the latest versions of control plane deployment tools. This ensures improved consistency and reliability in automated deployment and promotion processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-webpack-rails-tutorial/pull/745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->