### PR TITLE
Document cpflow app bootstrap

### DIFF
--- a/.controlplane/readme.md
+++ b/.controlplane/readme.md
@@ -57,6 +57,21 @@ The matching Control Plane resources are:
 | Staging app | `react-webpack-rails-tutorial-staging` |
 | Staging app secret dictionary | `react-webpack-rails-tutorial-staging-secrets` |
 
+Bootstrap the persistent staging app once before the first merge-to-master
+deploy:
+
+```sh
+cpflow setup-app -a react-webpack-rails-tutorial-staging --org shakacode-open-source-examples-staging --skip-post-creation-hook
+```
+
+`setup-app` reads `setup_app_templates` from `.controlplane/controlplane.yml`
+and creates the app identity, app secret dictionary, app secret policy, policy
+binding, and template resources. Use `--skip-post-creation-hook` so first-time
+bootstrap does not try to run database setup before a Docker image exists. For
+later template updates on an existing persistent app, use
+`cpflow apply-template` and make sure the app identity still has `reveal`
+permission on the app secret policy.
+
 ### Production Promotion
 
 Production promotion is part of the default demo flow, but the production token
@@ -80,6 +95,9 @@ The matching Control Plane resources are:
 | --- | --- |
 | Production app | `react-webpack-rails-tutorial-production` |
 | Production app secret dictionary | `react-webpack-rails-tutorial-production-secrets` |
+
+Bootstrap production the same way before the first promotion, using the
+production org and production-only secret values.
 
 All review, staging, and production secret dictionaries need these app runtime
 secrets:

--- a/.controlplane/shakacode-team.md
+++ b/.controlplane/shakacode-team.md
@@ -63,6 +63,18 @@ Generated caller workflows pass only the named secrets each upstream workflow
 needs. They do not use `secrets: inherit`; `CPLN_TOKEN_PRODUCTION` is supplied
 only by the protected `production` Environment after approval.
 
+Persistent staging and production apps must be bootstrapped once before the
+first deploy or promotion:
+
+```sh
+cpflow setup-app -a react-webpack-rails-tutorial-staging --org shakacode-open-source-examples-staging --skip-post-creation-hook
+cpflow setup-app -a react-webpack-rails-tutorial-production --org shakacode-open-source-examples-production --skip-post-creation-hook
+```
+
+Use `setup-app` for first-time bootstrap because it creates the app secret
+policy and identity binding. Use `cpflow apply-template` for later template
+updates to existing persistent apps.
+
 Advanced optional settings are documented upstream in the
 [`control-plane-flow` CI automation guide](https://github.com/shakacode/control-plane-flow/blob/main/docs/ci-automation.md).
 

--- a/.github/cpflow-help.md
+++ b/.github/cpflow-help.md
@@ -39,6 +39,16 @@ Optional overrides exist for forks, clones, and unusual apps:
 ## Staging And Production
 
 Staging deploys use the same `CPLN_TOKEN_STAGING` secret plus `STAGING_APP_NAME`.
+Before the first staging deploy, bootstrap the persistent staging app once:
+
+```sh
+cpflow setup-app -a "$STAGING_APP_NAME" --org "$CPLN_ORG_STAGING" --skip-post-creation-hook
+```
+
+`setup-app` creates the app identity, app secret dictionary, app secret policy,
+policy binding, and template resources. For later template updates on an
+existing persistent app, use `cpflow apply-template` and make sure the app
+identity has `reveal` permission on the app secret policy.
 
 Production promotion is part of the generated flow, but keep it protected:
 
@@ -52,6 +62,9 @@ Configure the `production` GitHub Environment with required reviewers and
 prevent self-review. The generated promotion wrapper passes only the staging
 token from repository secrets; GitHub injects `CPLN_TOKEN_PRODUCTION` only after
 the environment approval gate passes.
+
+Before the first promotion, bootstrap the production app the same way in the
+production org, using production-only secrets and values.
 
 ## Version Locking
 


### PR DESCRIPTION
## Summary
- document first-time staging bootstrap with setup-app --skip-post-creation-hook
- clarify why setup-app is preferred for new persistent apps before later apply-template updates
- add Shakacode team notes for staging and production bootstrap

## Verification
- bin/conductor-exec bin/test-cpflow-github-flow ruby /private/tmp/control-plane-flow-release-check.lWpUu0/repo/bin/cpflow
- bin/conductor-exec git diff --check
- post-merge staging deploy 26392435821 passed
- https://rails-3k23yt62491bp.cpln.app returned HTTP 200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application, workflow, or infrastructure code modifications.
> 
> **Overview**
> Adds **first-time bootstrap** guidance for persistent Control Plane staging and production apps across `.controlplane/readme.md`, `.controlplane/shakacode-team.md`, and `.github/cpflow-help.md`.
> 
> Operators should run `cpflow setup-app` with `--skip-post-creation-hook` once before the initial merge-to-master staging deploy or production promotion, so provisioning (identity, secret dictionary, policies, templates from `setup_app_templates`) happens without running DB setup before an image exists. Docs distinguish **first bootstrap** (`setup-app`) from **later template changes** (`cpflow apply-template` plus `reveal` on the app secret policy). Production is called out to use the production org and production-only secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb2fb8711d5f59c9422d391e7fe107fcef38d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation with explicit bootstrap steps required before first staging and production app deployments.
  * Enhanced setup guides with clearer app initialization instructions for persistent environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/react-webpack-rails-tutorial/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->