### PR TITLE
Clarify production environment secret setup

### DIFF
--- a/.controlplane/readme.md
+++ b/.controlplane/readme.md
@@ -89,6 +89,17 @@ self-review, and consider disabling administrator bypass. Do not store
 promotion wrapper does not use `secrets: inherit`; GitHub exposes the production
 token only after the environment approval gate passes.
 
+If promotion fails with
+`CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`,
+the token is missing from the environment scope. A repository or organization
+secret with the same name is not enough for this workflow. Create or verify the
+environment secret with:
+
+```sh
+gh secret set CPLN_TOKEN_PRODUCTION --repo shakacode/react-webpack-rails-tutorial --env production
+gh secret list --repo shakacode/react-webpack-rails-tutorial --env production
+```
+
 The matching Control Plane resources are:
 
 | Resource | Name |

--- a/.controlplane/readme.md
+++ b/.controlplane/readme.md
@@ -94,6 +94,8 @@ If promotion fails with
 the token is missing from the environment scope. A repository or organization
 secret with the same name is not enough for this workflow. Create or verify the
 environment secret with:
+You need permission to manage repository environments and secrets to run these
+commands.
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo shakacode/react-webpack-rails-tutorial --env production

--- a/.controlplane/shakacode-team.md
+++ b/.controlplane/shakacode-team.md
@@ -59,6 +59,15 @@ passes `production_environment: production`; the upstream reusable workflow runs
 its production job in that environment, and GitHub injects the production token
 only after approval.
 
+If promotion fails with
+`CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`,
+the token is missing from the environment scope. Configure it with:
+
+```sh
+gh secret set CPLN_TOKEN_PRODUCTION --repo shakacode/react-webpack-rails-tutorial --env production
+gh secret list --repo shakacode/react-webpack-rails-tutorial --env production
+```
+
 Generated caller workflows pass only the named secrets each upstream workflow
 needs. They do not use `secrets: inherit`; `CPLN_TOKEN_PRODUCTION` is supplied
 only by the protected `production` Environment after approval.

--- a/.controlplane/shakacode-team.md
+++ b/.controlplane/shakacode-team.md
@@ -61,7 +61,8 @@ only after approval.
 
 If promotion fails with
 `CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`,
-the token is missing from the environment scope. Configure it with:
+the token is missing from the environment scope. A repository or organization
+secret with the same name is not enough for this workflow. Configure it with:
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo shakacode/react-webpack-rails-tutorial --env production

--- a/.controlplane/shakacode-team.md
+++ b/.controlplane/shakacode-team.md
@@ -62,7 +62,10 @@ only after approval.
 If promotion fails with
 `CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`,
 the token is missing from the environment scope. A repository or organization
-secret with the same name is not enough for this workflow. Configure it with:
+secret with the same name is not enough for this workflow. Create or verify the
+environment secret with:
+You need permission to manage repository environments and secrets to run these
+commands.
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo shakacode/react-webpack-rails-tutorial --env production

--- a/.github/cpflow-help.md
+++ b/.github/cpflow-help.md
@@ -70,6 +70,17 @@ prevent self-review. The generated promotion wrapper passes only the staging
 token from repository secrets; GitHub injects `CPLN_TOKEN_PRODUCTION` only after
 the environment approval gate passes.
 
+If promotion fails with
+`CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`,
+the token is missing from the environment scope. A repository or organization
+secret with the same name is not enough for this workflow. Create or verify the
+environment secret with:
+
+```sh
+gh secret set CPLN_TOKEN_PRODUCTION --repo shakacode/react-webpack-rails-tutorial --env production
+gh secret list --repo shakacode/react-webpack-rails-tutorial --env production
+```
+
 Before the first promotion, bootstrap the production app the same way in the
 production org, using production-only secrets and values.
 

--- a/.github/cpflow-help.md
+++ b/.github/cpflow-help.md
@@ -75,6 +75,8 @@ If promotion fails with
 the token is missing from the environment scope. A repository or organization
 secret with the same name is not enough for this workflow. Create or verify the
 environment secret with:
+You need permission to manage repository environments and secrets to run these
+commands.
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo shakacode/react-webpack-rails-tutorial --env production


### PR DESCRIPTION
## Summary

- Add exact remediation steps for the `CPLN_TOKEN_PRODUCTION is not set` production promotion failure.
- Clarify that the production token must live on the protected `production` GitHub Environment, not as a repository or organization secret.
- Include `gh secret set/list --env production` commands in the generated help, team notes, and Control Plane docs.

Related upstream generator/docs PR: https://github.com/shakacode/control-plane-flow/pull/351

## Verification

- `git diff --check -- .github/cpflow-help.md .controlplane/shakacode-team.md .controlplane/readme.md`
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no actionable findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, CI, or secret-handling code changes.
> 
> **Overview**
> Adds matching **production promotion troubleshooting** to `.controlplane/readme.md`, `.controlplane/shakacode-team.md`, and `.github/cpflow-help.md`.
> 
> When promotion fails with `CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`, the docs now explain that the token must be on the protected **`production` GitHub Environment**, not a repo/org secret, and give **`gh secret set` / `gh secret list`** with `--env production`, plus a note that environment-management permissions are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b31af7b18468ff8a3baaa54a97e91a9d2df0f6b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting for failed production promotions when the production environment token is missing, clarifying that repository/org secrets are insufficient for this workflow.
  * Provided exact gh CLI commands to create and verify the required environment-scoped secret for production.
  * Harmonized guidance across promotion-related docs and added a note about required permissions to manage repository environments and secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->