### PR TITLE
Use native Control Plane image copy in production promotion

### DIFF
--- a/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -336,10 +336,10 @@ jobs:
           echo "image=${staging_image}" >> "$GITHUB_OUTPUT"
 
       - name: Copy image from staging
+        id: copy-image
         env:
           # Pass the upstream token via env rather than `-t` so it doesn't appear in /proc/<pid>/cmdline.
           CPLN_TOKEN_STAGING: ${{ secrets.CPLN_TOKEN_STAGING }}
-          CPLN_UPSTREAM_TOKEN: ${{ secrets.CPLN_TOKEN_STAGING }}
           PRODUCTION_APP_NAME: ${{ vars.PRODUCTION_APP_NAME }}
           CPLN_ORG_STAGING: ${{ vars.CPLN_ORG_STAGING }}
           CPLN_ORG_PRODUCTION: ${{ vars.CPLN_ORG_PRODUCTION }}
@@ -367,9 +367,39 @@ jobs:
             exit 1
           fi
 
+          staging_commit="${STAGING_IMAGE##*_}"
+          if [[ "${staging_commit}" == "${STAGING_IMAGE}" || -z "${staging_commit}" ]]; then
+            echo "::error::Staging image '${STAGING_IMAGE}' does not include the expected '_<commit>' suffix."
+            exit 1
+          fi
+
+          latest_number="$(
+            cpln image query --org "${CPLN_ORG_PRODUCTION}" --prop "name~${PRODUCTION_APP_NAME}:" -o json |
+              jq -r --arg prefix "${PRODUCTION_APP_NAME}:" \
+                '[.items[].name | select(startswith($prefix)) | (try capture("^[^:]+:(?<number>[0-9]+)") catch empty) | .number | tonumber] | max // 0'
+          )"
+          production_image="${PRODUCTION_APP_NAME}:$((latest_number + 1))_${staging_commit}"
+          source_image_ref="${CPLN_ORG_STAGING}.registry.cpln.io/${STAGING_IMAGE}"
+
+          upstream_profile="upstream-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          cleanup_upstream_profile() {
+            cpln profile delete "${upstream_profile}" >/dev/null 2>&1 || true
+          }
+          trap cleanup_upstream_profile EXIT
+
+          cpln profile create "${upstream_profile}" --token "${CPLN_TOKEN_STAGING}" >/dev/null
+          CPLN_PROFILE="${upstream_profile}" cpln image docker-login --org "${CPLN_ORG_STAGING}" >/dev/null
+          CPLN_PROFILE="${upstream_profile}" docker manifest inspect "${source_image_ref}" >/dev/null
+
           copy_status=1
           for attempt in $(seq 1 "${copy_image_attempts}"); do
-            if cpflow copy-image-from-upstream -a "${PRODUCTION_APP_NAME}" --org "${CPLN_ORG_PRODUCTION}" --image "${STAGING_IMAGE}"; then
+            if cpln image copy "${STAGING_IMAGE}" \
+              --profile "${upstream_profile}" \
+              --org "${CPLN_ORG_STAGING}" \
+              --to-profile default \
+              --to-org "${CPLN_ORG_PRODUCTION}" \
+              --to-name "${production_image}" \
+              --cleanup; then
               copy_status=0
               break
             else
@@ -388,6 +418,8 @@ jobs:
             echo "::error::Could not copy staging image '${STAGING_IMAGE}' from '${CPLN_ORG_STAGING}' to '${CPLN_ORG_PRODUCTION}' after ${copy_image_attempts} attempt(s)."
             exit "${copy_status}"
           fi
+
+          echo "image=${production_image}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy image to production
         env:
@@ -553,7 +585,7 @@ jobs:
           HEALTHY: ${{ steps.health-check.outputs.healthy }}
           PREVIOUS_IMAGE: ${{ steps.capture-current.outputs.current_image }}
           PREVIOUS_VERSION: ${{ steps.capture-current.outputs.current_version }}
-          DEPLOYED_IMAGE: ${{ steps.staging-image.outputs.image }}
+          DEPLOYED_IMAGE: ${{ steps.copy-image.outputs.image }}
         shell: bash
         run: |
           {

--- a/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -387,19 +387,19 @@ jobs:
           }
           trap cleanup_upstream_profile EXIT
 
-          cpln profile create "${upstream_profile}" --token "${CPLN_TOKEN_STAGING}" >/dev/null
+          cleanup_upstream_profile
+          CPLN_TOKEN="${CPLN_TOKEN_STAGING}" cpln profile create "${upstream_profile}" >/dev/null
           CPLN_PROFILE="${upstream_profile}" cpln image docker-login --org "${CPLN_ORG_STAGING}" >/dev/null
-          CPLN_PROFILE="${upstream_profile}" docker manifest inspect "${source_image_ref}" >/dev/null
 
           copy_status=1
           for attempt in $(seq 1 "${copy_image_attempts}"); do
-            if cpln image copy "${STAGING_IMAGE}" \
+            if CPLN_PROFILE="${upstream_profile}" docker manifest inspect "${source_image_ref}" >/dev/null &&
+              cpln image copy "${STAGING_IMAGE}" \
               --profile "${upstream_profile}" \
               --org "${CPLN_ORG_STAGING}" \
               --to-profile default \
               --to-org "${CPLN_ORG_PRODUCTION}" \
-              --to-name "${production_image}" \
-              --cleanup; then
+              --to-name "${production_image}"; then
               copy_status=0
               break
             else
@@ -585,7 +585,7 @@ jobs:
           HEALTHY: ${{ steps.health-check.outputs.healthy }}
           PREVIOUS_IMAGE: ${{ steps.capture-current.outputs.current_image }}
           PREVIOUS_VERSION: ${{ steps.capture-current.outputs.current_version }}
-          DEPLOYED_IMAGE: ${{ steps.copy-image.outputs.image }}
+          COPIED_IMAGE: ${{ steps.copy-image.outputs.image }}
         shell: bash
         run: |
           {
@@ -593,13 +593,15 @@ jobs:
             echo
             if [[ "${HEALTHY}" == "true" ]]; then
               echo "✅ Status: deployment successful"
+              deployed_image="${COPIED_IMAGE}"
             else
               echo "❌ Status: deployment failed"
+              deployed_image="${PREVIOUS_IMAGE}"
             fi
             echo
             echo "Previous image: \`${PREVIOUS_IMAGE}\`"
             echo "Previous version: ${PREVIOUS_VERSION}"
-            echo "Deployed image: \`${DEPLOYED_IMAGE}\`"
+            echo "Deployed image: \`${deployed_image}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   create-github-release:


### PR DESCRIPTION
## Summary
- replace the production promotion copy step with native `cpln image copy`
- create an explicit temporary staging profile from `CPLN_TOKEN_STAGING`, authenticate Docker to the staging registry, and inspect the source manifest before copying
- preserve retry handling, rollback behavior, and release summary output while reporting the copied production image tag

## Why
Fresh runs after #754/#755 prove that `CPLN_TOKEN_PRODUCTION` is now visible and rollback works, but `cpflow copy-image-from-upstream` still fails opaquely during the staging registry pull. Control Plane docs recommend `cpln image copy` with `--to-profile` for cross-org copies with different credentials, which matches this promotion flow and gives Actions a clearer auth/copy boundary.

Observed failed runs:
- https://github.com/shakacode/react-webpack-rails-tutorial/actions/runs/26840408465
- https://github.com/shakacode/react-webpack-rails-tutorial/actions/runs/26846980505

## Verification
- `git diff --check HEAD~1..HEAD`
- `bin/conductor-exec bin/test-cpflow-github-flow`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only the production promotion workflow but alters cross-org registry auth, image naming, and what operators see as the deployed tag; a mis-copy or tag collision could block or mislabel production releases.
> 
> **Overview**
> The **Copy image from staging** step no longer calls `cpflow copy-image-from-upstream`. It now builds a **new production image name** (next numeric tag under `PRODUCTION_APP_NAME:` plus the commit suffix from the staging tag), uses a **throwaway staging `cpln` profile** and `docker manifest inspect` on the staging registry ref, then copies with **`cpln image copy`** into the production org (`--to-profile default`). Retries and failure handling stay the same; the step exposes **`copy-image.outputs.image`** for downstream reporting.
> 
> The **Promotion summary** reports the **copied production tag** when the health check passes, and the **previous production image** when promotion fails—instead of echoing the staging image name as “deployed.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316555de33023d9f7be8c941e40ffd18013990ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved production promotion workflow: stronger validation of staging images, automatic computation and assignment of the new production image tag, and more reliable image-copying with preserved retry behavior.
  * Ensures downstream steps receive the computed production image tag and cleans up temporary credentials/profiles created during promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->