### PR TITLE
Use staging token directly for production image copy source

### DIFF
--- a/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -381,21 +381,20 @@ jobs:
           production_image="${PRODUCTION_APP_NAME}:$((latest_number + 1))_${staging_commit}"
           source_image_ref="${CPLN_ORG_STAGING}.registry.cpln.io/${STAGING_IMAGE}"
 
-          upstream_profile="upstream-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          cleanup_upstream_profile() {
-            cpln profile delete "${upstream_profile}" >/dev/null 2>&1 || true
+          docker_config_dir="$(mktemp -d)"
+          cleanup_copy_credentials() {
+            rm -rf "${docker_config_dir}"
           }
-          trap cleanup_upstream_profile EXIT
+          trap cleanup_copy_credentials EXIT
 
-          cleanup_upstream_profile
-          CPLN_TOKEN="${CPLN_TOKEN_STAGING}" cpln profile create "${upstream_profile}" >/dev/null
-          CPLN_PROFILE="${upstream_profile}" cpln image docker-login --org "${CPLN_ORG_STAGING}" >/dev/null
+          export DOCKER_CONFIG="${docker_config_dir}"
 
           copy_status=1
           for attempt in $(seq 1 "${copy_image_attempts}"); do
-            if CPLN_PROFILE="${upstream_profile}" docker manifest inspect "${source_image_ref}" >/dev/null &&
+            if CPLN_TOKEN="${CPLN_TOKEN_STAGING}" cpln image docker-login --org "${CPLN_ORG_STAGING}" >/dev/null &&
+              docker manifest inspect "${source_image_ref}" >/dev/null &&
+              CPLN_TOKEN="${CPLN_TOKEN_STAGING}" \
               cpln image copy "${STAGING_IMAGE}" \
-              --profile "${upstream_profile}" \
               --org "${CPLN_ORG_STAGING}" \
               --to-profile default \
               --to-org "${CPLN_ORG_PRODUCTION}" \


### PR DESCRIPTION
## Summary
- remove the temporary `cpln profile create` path from the production copy step
- run staging docker-login, manifest inspect, and source-side `cpln image copy` with `CPLN_TOKEN_STAGING` scoped to those commands
- keep `--to-profile default` so the destination copy still uses the production profile created by setup

## Why
The fresh post-#756 production run failed with:

`/org/shakacode-open-source-examples-production/serviceaccount/github-actions-production is not granted [view] on /org/shakacode-open-source-examples-staging`

That shows `CPLN_TOKEN=... cpln profile create` did not store the staging token in the temporary profile. The copy source needs the staging token directly, while the destination should keep using the default production profile.

Failed run: https://github.com/shakacode/react-webpack-rails-tutorial/actions/runs/26849170364

## Verification
- `git diff --check -- .github/workflows/cpflow-promote-staging-to-production.yml`
- `bin/conductor-exec bin/test-cpflow-github-flow`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production promotion credentials and cross-org image copy; failure would block releases but does not alter runtime app code.
> 
> **Overview**
> Fixes staging→production image promotion in **cpflow-promote-staging-to-production** when a temporary Control Plane profile did not actually hold the staging token (production runs failed with missing **view** on the staging org).
> 
> The **Copy image from staging** step drops **`cpln profile create` / `--profile` upstream** and instead runs **staging** `docker-login`, **`docker manifest inspect`**, and the source side of **`cpln image copy`** with **`CPLN_TOKEN_STAGING`** on each command. Credentials go in an isolated **`DOCKER_CONFIG`** temp dir with cleanup on exit. Destination copy still uses **`--to-profile default`** (production profile from setup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 937cbfc1d0cfc479620a09218ab3bb7b4d069585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced staging-to-production promotion workflow with improved error handling and validation during Docker image copying.
  * Streamlined authentication process and added manifest verification before each copy attempt.
  * Improved temporary file cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->