### PR TITLE
Copy production image with direct Docker registry auth

### DIFF
--- a/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -340,6 +340,7 @@ jobs:
         env:
           # Pass the upstream token via env rather than `-t` so it doesn't appear in /proc/<pid>/cmdline.
           CPLN_TOKEN_STAGING: ${{ secrets.CPLN_TOKEN_STAGING }}
+          CPLN_TOKEN_PRODUCTION: ${{ secrets.CPLN_TOKEN_PRODUCTION }}
           PRODUCTION_APP_NAME: ${{ vars.PRODUCTION_APP_NAME }}
           CPLN_ORG_STAGING: ${{ vars.CPLN_ORG_STAGING }}
           CPLN_ORG_PRODUCTION: ${{ vars.CPLN_ORG_PRODUCTION }}
@@ -379,7 +380,10 @@ jobs:
                 '[.items[].name | select(startswith($prefix)) | (try capture("^[^:]+:(?<number>[0-9]+)") catch empty) | .number | tonumber] | max // 0'
           )"
           production_image="${PRODUCTION_APP_NAME}:$((latest_number + 1))_${staging_commit}"
+          staging_registry="${CPLN_ORG_STAGING}.registry.cpln.io"
+          production_registry="${CPLN_ORG_PRODUCTION}.registry.cpln.io"
           source_image_ref="${CPLN_ORG_STAGING}.registry.cpln.io/${STAGING_IMAGE}"
+          production_image_ref="${CPLN_ORG_PRODUCTION}.registry.cpln.io/${production_image}"
 
           docker_config_dir="$(mktemp -d)"
           cleanup_copy_credentials() {
@@ -391,14 +395,14 @@ jobs:
 
           copy_status=1
           for attempt in $(seq 1 "${copy_image_attempts}"); do
-            if CPLN_TOKEN="${CPLN_TOKEN_STAGING}" cpln image docker-login --org "${CPLN_ORG_STAGING}" >/dev/null &&
+            if printf '%s' "${CPLN_TOKEN_STAGING}" |
+              docker login "${staging_registry}" -u '<token>' --password-stdin >/dev/null &&
+              printf '%s' "${CPLN_TOKEN_PRODUCTION}" |
+              docker login "${production_registry}" -u '<token>' --password-stdin >/dev/null &&
               docker manifest inspect "${source_image_ref}" >/dev/null &&
-              CPLN_TOKEN="${CPLN_TOKEN_STAGING}" \
-              cpln image copy "${STAGING_IMAGE}" \
-              --org "${CPLN_ORG_STAGING}" \
-              --to-profile default \
-              --to-org "${CPLN_ORG_PRODUCTION}" \
-              --to-name "${production_image}"; then
+              docker pull "${source_image_ref}" &&
+              docker tag "${source_image_ref}" "${production_image_ref}" &&
+              docker push "${production_image_ref}"; then
               copy_status=0
               break
             else


### PR DESCRIPTION
## Summary
- replace the source-side cpln docker-login/cpln image copy path with direct Docker registry auth
- authenticate to staging and production registries via docker login --password-stdin
- copy by docker pull, docker tag, and docker push, while preserving the generated production image tag output

## Why
The post-#757 production run got past the previous profile-create issue, but failed because cpln image docker-login still configured Docker with the default production profile for the staging registry.

Then Docker could not pull the staging image. Control Plane image docs document the CI-safe direct registry path using docker login with the token on stdin. This keeps staging and production registry credentials explicit and avoids the cpln profile/credential-helper mismatch.

Failed run: https://github.com/shakacode/react-webpack-rails-tutorial/actions/runs/26849578678

## Verification
- git diff --check -- .github/workflows/cpflow-promote-staging-to-production.yml
- bin/conductor-exec bin/test-cpflow-github-flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production container images are published during promotion; a misconfiguration could block releases or push to the wrong registry, though tagging and retries are preserved.
> 
> **Overview**
> The **Copy image from staging** step in `cpflow-promote-staging-to-production.yml` no longer uses `cpln image docker-login` and `cpln image copy`. It now logs into the staging and production Control Plane registries with **`docker login --password-stdin`** (staging and production tokens via env), then **pulls** the staging image, **tags** it with the same incremented production name (`<app>:<n+1>_<commit>`), and **pushes** to production.
> 
> That fixes CI failures where `cpln image docker-login` wired Docker to the wrong org/profile so the staging image could not be pulled. Retry logic, isolated `DOCKER_CONFIG`, and the step’s `image` output are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4b524ed0fc31e4297f8ef9c7f93b0990e4bf1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production deployment workflow to streamline staging-to-production image promotion with improved registry-based image handling mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->