### PR TITLE
Update react-on-rails-rsc to 19.0.5-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-intl": "^6.4.4",
     "react-on-rails-pro": "16.7.0-rc.3",
     "react-on-rails-pro-node-renderer": "16.7.0-rc.3",
-    "react-on-rails-rsc": "19.0.4",
+    "react-on-rails-rsc": "19.0.5-rc.5",
     "react-redux": "^8.1.0",
     "react-router": "^6.13.0",
     "react-router-dom": "^6.13.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-intl": "^6.4.4",
     "react-on-rails-pro": "16.7.0-rc.3",
     "react-on-rails-pro-node-renderer": "16.7.0-rc.3",
-    "react-on-rails-rsc": "19.0.5-rc.5",
+    "react-on-rails-rsc": "19.0.5-rc.6",
     "react-redux": "^8.1.0",
     "react-router": "^6.13.0",
     "react-router-dom": "^6.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8779,10 +8779,10 @@ react-on-rails-pro@16.7.0-rc.3:
   dependencies:
     react-on-rails "16.7.0-rc.3"
 
-react-on-rails-rsc@19.0.5-rc.5:
-  version "19.0.5-rc.5"
-  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.0.5-rc.5.tgz#2dc1dd30764be9b879a951ecc4d2e921af95952e"
-  integrity sha512-NTe3g34iR0ya8XFUpwbqE37ff4x5YGZEGowWGbY4o/wqNPykICDH5Nsd7MjqUSwun5NYqI92FHKHSEhpHgPq2A==
+react-on-rails-rsc@19.0.5-rc.6:
+  version "19.0.5-rc.6"
+  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.0.5-rc.6.tgz#dfc44634137cc6044cda21b2c79dee5eb01a899b"
+  integrity sha512-BCnSJ4lzLP6lqegQlr5smJW/54NAEwnQy1OMLBYUwXYKXEozuLlGH/GzLf0F0nR69fDmKyUL51fzcg6Khm4AkA==
   dependencies:
     acorn-loose "^8.3.0"
     neo-async "^2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8779,10 +8779,10 @@ react-on-rails-pro@16.7.0-rc.3:
   dependencies:
     react-on-rails "16.7.0-rc.3"
 
-react-on-rails-rsc@19.0.4:
-  version "19.0.4"
-  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.0.4.tgz#a605fbaa82a0bece504de1ef0b8d5c6fae5d6be3"
-  integrity sha512-KtHYz0opcXJk+Zw5aabjNiaszzpTdFgs1YfSLIZJSzU5SpddUw7b08epkxeJq/TCpR60Q9vsjxX3Q3OWJ97tMg==
+react-on-rails-rsc@19.0.5-rc.5:
+  version "19.0.5-rc.5"
+  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.0.5-rc.5.tgz#2dc1dd30764be9b879a951ecc4d2e921af95952e"
+  integrity sha512-NTe3g34iR0ya8XFUpwbqE37ff4x5YGZEGowWGbY4o/wqNPykICDH5Nsd7MjqUSwun5NYqI92FHKHSEhpHgPq2A==
   dependencies:
     acorn-loose "^8.3.0"
     neo-async "^2.6.1"


### PR DESCRIPTION
## Summary
- Update `react-on-rails-rsc` to `19.0.5-rc.6`.
- Refresh `yarn.lock` to the published rc.6 package integrity.

## Rationale
- There is no stable `react-on-rails-rsc@19.0.5` on npm yet; rc.6 is the current published release candidate for this integration path.
- Follow-up: move to stable `19.0.5` after it is published.

## Verification
- `npm view react-on-rails-rsc@19.0.5-rc.6 version dist.integrity dist.shasum --json --prefer-online`
- `npm pack react-on-rails-rsc@19.0.5-rc.6 --pack-destination /tmp/ror-rsc-registry-pack-rc6 --prefer-online`
- `yarn install --frozen-lockfile --non-interactive`
- `bundle exec rake react_on_rails:locale`
- `bundle exec rails react_on_rails:generate_packs`
- `git diff --check`

## Note
- The branch name was created for rc.4 before this PR was refreshed to later release candidates. The PR title, `package.json`, `yarn.lock`, and this body are authoritative for rc.6.
