### PR TITLE
perf: use after_create_commit for comment relaying

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,5 +2,5 @@
 
 class Comment < ApplicationRecord
   validates :author, :text, presence: true
-  after_commit { CommentRelayJob.perform_later(self) }
+  after_create_commit { CommentRelayJob.perform_later(self) }
 end


### PR DESCRIPTION
Optimizes the Comment model by changing `after_commit` to `after_create_commit`. This ensures the `CommentRelayJob` is only triggered upon the creation of a new comment, avoiding unnecessary broadcast operations when existing comments are updated. This improves system efficiency and reduces unnecessary WebSocket traffic. Closes #0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized comment relay processing timing to improve efficiency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->