### PR TITLE
Bump react-on-rails-rsc to 19.2.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-intl": "^6.4.4",
     "react-on-rails-pro": "17.0.0-rc.6",
     "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
-    "react-on-rails-rsc": "19.2.0-rc.3",
+    "react-on-rails-rsc": "19.2.0-rc.4",
     "react-redux": "^8.1.0",
     "react-router": "^6.13.0",
     "react-router-dom": "^6.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8779,10 +8779,10 @@ react-on-rails-pro@17.0.0-rc.6:
   dependencies:
     react-on-rails "17.0.0-rc.6"
 
-react-on-rails-rsc@19.2.0-rc.3:
-  version "19.2.0-rc.3"
-  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.2.0-rc.3.tgz#9b0d24a78c12a5e3d45d711d1c8612d4387cac08"
-  integrity sha512-lthw7rRbPdUOeZQMVR2rH1FdA3sp7wiZfMljmld1c/2epYtA7SYLLhg7jTn9FcVEIjWLZiyzC7GkNrNnLB4IOQ==
+react-on-rails-rsc@19.2.0-rc.4:
+  version "19.2.0-rc.4"
+  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.2.0-rc.4.tgz#97ea2bf3c5e760fe900ba2a2330fac0e3149fe81"
+  integrity sha512-Jm9822vmAvXPbQ3gyx8B5RwbGcmxEXZ1eMEoVxd3rsnnxuZ7B35dr11Ygy2FBPPq4v5sJa/PFWGir/m8Cg1b9Q==
   dependencies:
     acorn-loose "^8.3.0"
     neo-async "^2.6.1"


### PR DESCRIPTION
## Summary
- Bump `react-on-rails-rsc` from `19.2.0-rc.3` to `19.2.0-rc.4`.
- Refresh Yarn lockfile resolution and integrity for the new RC.

## Verification
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack yarn install --frozen-lockfile --ignore-scripts`
- Exact stale-pin scan: `rg -n "19\.2\.0-rc\.3" /Users/justin/.codex/downstream-rc6 --glob "!node_modules/**" --glob "!public/lighthouse-reports/**" --glob "!tmp/**" --glob "!log/**"` returned no matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to a newer release candidate version, which may include stability and compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->