### PR TITLE
AGENTS.md: add Agent Workflow Configuration seam

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,74 @@ React on Rails demo app — a Rails application with React, Redux, Tailwind CSS,
 
 - `prompts/`: shared prompt templates for Codex, GPT, and other non-Claude tools
 
+## Agent Workflow Configuration
+
+Shared workflow skills from
+[`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows) are
+repo-agnostic: they carry the workflow logic but defer every repo-specific
+command, branch, label, path, and policy to this section. When a shared skill
+says "run the repo's local validation" or "use the hosted-CI trigger," the
+concrete value is here. This is a small tutorial app, so many advanced
+process concepts (hosted-CI gating, benchmarks, merge ledgers, coordination
+backends) genuinely do not apply and are marked `n/a` with a pointer to the
+real file or workflow. Validate this seam with
+`agent-workflow-seam-doctor --root . --shared <agent-workflows-root>`. Where a
+value is already documented elsewhere in this file, this section references that
+section instead of duplicating it.
+
+- **Base branch**: `master` (fetch and compare via `origin/master`; all CI
+  workflows in `.github/workflows/` trigger on `push`/`pull_request` to `master`).
+- **Pre-push local validation**: `bin/ci` — runs setup, RuboCop, ESLint, the test
+  asset build, RSpec, and Jest in order (steps defined in `config/ci.rb`). The
+  equivalent Rake entrypoint is `bundle exec rake ci:all`. Run tool-version-sensitive
+  commands through `bin/conductor-exec` (see the **Conductor Compatibility** section).
+- **CI change detector**: n/a — there is no suite-routing detector; every PR runs
+  all three workflows (`.github/workflows/rspec_test.yml`, `lint_test.yml`,
+  `js_test.yml`) in full.
+- **Hosted-CI trigger**: n/a — no `+ci-*` PR-comment commands or hosted-CI labels.
+  CI runs automatically on push and pull_request to `master`. The separate
+  `@claude` PR/issue mention triggers the Claude Code agent via
+  `.github/workflows/claude.yml`.
+- **CI parity environment**: n/a — no `act` or local-runner image is documented.
+  Reproduce CI-only failures from the exact GitHub Actions jobs in
+  `.github/workflows/*.yml`: `runs-on: ubuntu-latest`, Ruby `3.4.6`, Node `22.x`,
+  `services.postgres: postgres:11-alpine` (`rspec_test.yml`), and the listed env
+  vars (`RAILS_ENV=test`, `NODE_ENV=test`, `DATABASE_URL`, `DRIVER=selenium_chrome`,
+  `RENDERER_PASSWORD`). Record any unverified runner/service gap as `UNKNOWN`.
+- **Secret redaction patterns**: redact values for environment variables or log
+  fields whose names contain `SECRET`, `TOKEN`, `KEY`, `PASSWORD`, `CREDENTIAL`,
+  `PASSPHRASE`, or `PRIVATE`, plus the repo-specific names `CLAUDE_CODE_OAUTH_TOKEN`,
+  `RENDERER_PASSWORD`, `GITHUB_TOKEN`, `GH_TOKEN`, and `DATABASE_URL` (contains
+  credentials). These patterns favor conservative over-redaction of logs, prompts,
+  and issue comments. The repo-specific entries are public identifier names, not
+  values; list them so agents redact exact aliases even when generic patterns match.
+- **Benchmark labels**: n/a — no performance-benchmark workflow or labels in this repo.
+- **Follow-up issue prefix**: n/a — no follow-up-issue convention is documented;
+  default to not opening new issues.
+- **Changelog**: `/CHANGELOG.md`, user-visible changes only. There is no changelog
+  automation (no Rake task or script); edit the file by hand following its existing
+  reverse-chronological dated-section format.
+- **Lint / format**: `bundle exec rake lint` (full suite: RuboCop, ESLint, scss_lint);
+  `bin/rubocop` or `bundle exec rake "lint:rubocop[fix]"` (Ruby, with autofix);
+  `bundle exec rubocop -a` (Ruby autofix); `yarn lint:eslint` (JS check),
+  `yarn lint` (ESLint autofix + Prettier write); `yarn lint:prettier` (Prettier
+  check, `.js`/`.jsx`). See the **Build and Test Commands** section.
+- **Merge ledger**: n/a — no machine-checkable per-PR merge-readiness script exists.
+- **Docs checks**: n/a — no markdown link checker or docs-sidebar verifier in this repo.
+- **Tests**: RSpec via `bin/rspec` or `bundle exec rake ci:rspec`; Jest (client JS)
+  via `yarn test:client` or `bundle exec rake ci:js`. The full local gate is
+  `bin/ci` / `bundle exec rake ci:all`. No separate e2e suite is configured.
+- **Build / type checks**: build test assets with `yarn build:test` (and
+  `yarn res:build` for ReScript). Type checks: n/a — TypeScript is a dependency but
+  there is no `tsc`/type-check script; ReScript is compiled by `yarn res:build`.
+- **Review gate**: `claude-review` — the automated Claude Code review in
+  `.github/workflows/claude-code-review.yml` runs on every PR (opened, synchronize,
+  ready_for_review, reopened) and posts inline/PR comments.
+- **Approval-exempt change categories**: n/a — no standing approval-exemption policy
+  is documented; treat all changes as requiring normal review.
+- **Coordination backend**: n/a — this repo uses no shared agent-coordination backend;
+  rely on GitHub PR/issue state and assignment for coordination.
+
 ## Build and Test Commands
 
 ```bash


### PR DESCRIPTION
## What

Adds an `## Agent Workflow Configuration` section to `AGENTS.md`, positioned near
the top right after the Project Overview (mirroring how `react_on_rails`
positions its seam).

This is the **only** file changed (68 insertions, additive).

## Why

`shakacode/agent-workflows` publishes portable agent skills (issue/PR batching,
review-comment triage, verification, changelog updates, CI routing, etc.). Each
skill carries the workflow logic but defers every repo-specific command, branch,
label, path, and policy to a small, validated seam in the consumer repo's
`AGENTS.md`. Adding this seam lets those shared skills resolve **this** repo's
real commands and policy instead of guessing.

The contract and rationale live in
[`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows)
(`docs/seam-design.md`).

## How values were determined

Every value was read from the repo on `master` — `config/ci.rb`, `bin/ci`,
`lib/tasks/*.rake`, `package.json` scripts, `.github/workflows/*.yml`,
`CHANGELOG.md`, and the existing `AGENTS.md`. Nothing was fabricated.

## Validation

```
$ agent-workflow-seam-doctor --root . --shared <agent-workflows-root>
PASS agent workflow seam is complete
```

All 16 required seam keys are present and no key contains an unresolved
`<placeholder>` value.

## Keys marked `n/a` (concept genuinely does not apply to this tutorial app)

Each points at the real file/workflow that governs the concept:

- **CI change detector** — no suite-routing detector; every PR runs all three
  workflows in full (`.github/workflows/{rspec_test,lint_test,js_test}.yml`).
- **Hosted-CI trigger** — no `+ci-*` commands or hosted-CI labels; CI auto-runs on
  push/PR to `master`. (The `@claude` mention triggers `.github/workflows/claude.yml`.)
- **CI parity environment** — no `act`/runner image documented; reproduce from the
  exact job specs in `.github/workflows/*.yml` (ubuntu-latest, Ruby 3.4.6, Node
  22.x, postgres:11-alpine).
- **Benchmark labels** — no benchmark workflow or labels exist.
- **Follow-up issue prefix** — no follow-up-issue convention documented.
- **Merge ledger** — no per-PR merge-readiness script exists.
- **Docs checks** — no markdown link checker or docs-sidebar verifier.
- **Build / type checks → type checks** — TypeScript is a dependency but there is no
  `tsc`/type-check script; ReScript is compiled by `yarn res:build`.
- **Approval-exempt change categories** — no standing approval-exemption policy.
- **Coordination backend** — no shared agent-coordination backend; coordination is
  via GitHub PR/issue state.

No keys were left as `UNKNOWN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
