### PR TITLE
Bump React on Rails RSC to final 19.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,13 @@ assets_bundler: rspack
 
 ### Version Targets
 
-- `react_on_rails_pro` gem: `17.0.0.rc.3`
-- `react-on-rails-pro` npm package: `17.0.0-rc.3`
-- `react-on-rails-pro-node-renderer` npm package: `17.0.0-rc.3`
-- `react-on-rails-rsc` npm package: `19.0.5-rc.7`
+- `react_on_rails_pro` gem: `17.0.0.rc.6`
+- `react-on-rails-pro` npm package: `17.0.0-rc.6`
+- `react-on-rails-pro-node-renderer` npm package: `17.0.0-rc.6`
+- `react-on-rails-rsc` npm package: `19.2.0`
 - `shakapacker` gem/npm package: `10.1.0`
 - `@rspack/core` and `@rspack/cli`: `2.0.0-beta.7`
-- `react`: `~19.0.4` (minimum for React Server Components)
+- `react`: `~19.2.7` (minimum for React Server Components)
 
 ### Why Rspack
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-intl": "^6.4.4",
     "react-on-rails-pro": "17.0.0-rc.6",
     "react-on-rails-pro-node-renderer": "17.0.0-rc.6",
-    "react-on-rails-rsc": "19.2.0-rc.4",
+    "react-on-rails-rsc": "19.2.0",
     "react-redux": "^8.1.0",
     "react-router": "^6.13.0",
     "react-router-dom": "^6.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8779,10 +8779,10 @@ react-on-rails-pro@17.0.0-rc.6:
   dependencies:
     react-on-rails "17.0.0-rc.6"
 
-react-on-rails-rsc@19.2.0-rc.4:
-  version "19.2.0-rc.4"
-  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.2.0-rc.4.tgz#97ea2bf3c5e760fe900ba2a2330fac0e3149fe81"
-  integrity sha512-Jm9822vmAvXPbQ3gyx8B5RwbGcmxEXZ1eMEoVxd3rsnnxuZ7B35dr11Ygy2FBPPq4v5sJa/PFWGir/m8Cg1b9Q==
+react-on-rails-rsc@19.2.0:
+  version "19.2.0"
+  resolved "https://registry.npmjs.org/react-on-rails-rsc/-/react-on-rails-rsc-19.2.0.tgz#3b539142048047193d524265fabdc81356bd482f"
+  integrity sha512-4PlfNFWGHl029al/yi10G3fcREbTwzqQ45uqYs6i9Baqds2OROyWp1xdorfX4Ok46IVJjje14SeaJVyN8pGDGg==
   dependencies:
     acorn-loose "^8.3.0"
     neo-async "^2.6.1"


### PR DESCRIPTION
## Summary
- updates the tutorial starter app to `react-on-rails-rsc` final `19.2.0`
- refreshes `yarn.lock` for the final package tarball
- updates README version-target references from the RC line to the current final RSC package

## Rationale
The tutorial should install and document the final RSC package now that `19.2.0` has been promoted from RC.

## Verification
- `bin/ci` passed setup, RuboCop, ESLint, ReScript, generated packs, and client/server/RSC webpack builds; the first RSpec phase failed only because the Pro node renderer was not running on `127.0.0.1:3800`
- started the node renderer, then `bin/conductor-exec bin/rspec` passed: 48 examples
- `bin/conductor-exec yarn test:client` passed: 4 suites, 16 tests
- `rg -n "19\\.2\\.0-rc\\.4" .` returned no matches in this checkout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the version compatibility matrix in the README to reflect the latest supported releases.
* **Chores**
  * Bumped React Server Components package versions and aligned the minimum supported React version accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->