### PR TITLE
Fix SSR renderer URL VM global

### DIFF
--- a/renderer/node-renderer.js
+++ b/renderer/node-renderer.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { URL } = require('node:url');
 const { reactOnRailsProNodeRenderer } = require('react-on-rails-pro-node-renderer');
 
 const isProduction = process.env.NODE_ENV === 'production';

--- a/spec/requests/server_render_check_spec.rb
+++ b/spec/requests/server_render_check_spec.rb
@@ -11,6 +11,13 @@ describe "Server Rendering" do
       .to include("Comments")
   end
 
+  it "server renders RouterApp NavLinks that require the URL VM global" do
+    get root_path
+    html_nodes = Nokogiri::HTML(response.body)
+
+    expect(html_nodes.at_css("#RouterApp-react-component-0 a[href='/react-router']").text).to eq("Route")
+  end
+
   it "generates no server rendered HTML if server rendering not enabled" do
     get simple_path
     html_nodes = Nokogiri::HTML(response.body)

--- a/spec/requests/server_render_check_spec.rb
+++ b/spec/requests/server_render_check_spec.rb
@@ -13,7 +13,7 @@ describe "Server Rendering" do
 
   it "server renders RouterApp NavLinks that require the URL VM global" do
     get root_path
-    html_nodes = Nokogiri::HTML(response.body)
+    html_nodes = response.parsed_body
 
     expect(html_nodes.at_css("#RouterApp-react-component-0 a[href='/react-router']").text).to eq("Route")
   end


### PR DESCRIPTION
Closes #780

Follow-up for shakacode/react_on_rails#3823.

- inject Node's standard `URL` constructor into the renderer VM context
- cover SSR of the RouterApp NavLink path that requires `URL`

Validation:
- focused request spec against a fresh isolated renderer
- `bin/conductor-exec bin/ci` against a fresh isolated renderer

No React on Rails dependency or lockfile changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-rendered navigation so URL-based links render correctly.
  * Fixed missing URL support in server-rendered pages.

* **Tests**
  * Added request spec coverage to verify server-rendered navigation link presence and content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->