### PR TITLE
Preserve review-app renderer startup grace

### DIFF
--- a/.controlplane/templates/node-renderer.yml
+++ b/.controlplane/templates/node-renderer.yml
@@ -33,13 +33,6 @@ spec:
           # The React on Rails Pro Node Renderer speaks cleartext HTTP/2 (h2c).
           # Rails/Thruster stays `http`; this renderer port intentionally differs.
           protocol: http2
-      startupProbe:
-        tcpSocket:
-          port: 3800
-        # Give the boot seed enough room for Rails boot plus previous-bundle
-        # fetches; readiness still waits for the renderer port before Rails rolls.
-        failureThreshold: 60
-        periodSeconds: 2
       readinessProbe:
         tcpSocket:
           port: 3800
@@ -48,6 +41,7 @@ spec:
       livenessProbe:
         tcpSocket:
           port: 3800
+        initialDelaySeconds: 120
         failureThreshold: 3
         periodSeconds: 10
   defaultOptions:

--- a/bin/test-cpflow-github-flow
+++ b/bin/test-cpflow-github-flow
@@ -12,6 +12,51 @@ fi
 echo "==> cpflow github-flow-readiness"
 "${cpflow_cmd[@]}" github-flow-readiness
 
+echo "==> check node renderer probe template"
+ruby <<'RUBY'
+require "yaml"
+
+template = File.read(".controlplane/templates/node-renderer.yml")
+rendered = template.gsub(/\{\{[A-Z_]+\}\}/, "template-placeholder")
+container = YAML.safe_load(rendered).fetch("spec").fetch("containers").fetch(0)
+
+expected_args = [
+  "bash",
+  "-lc",
+  <<~'SHELL',
+    # The rake task warns and continues on bundle fetch misses so rollout
+    # does not wedge; unexpected task failures still stop the shell.
+    set -e
+    bundle exec rake react_on_rails_pro:pre_seed_renderer_cache
+    exec yarn node-renderer
+  SHELL
+]
+expected_ports = [{ "number" => 3800, "protocol" => "http2" }]
+expected_readiness_probe = {
+  "tcpSocket" => { "port" => 3800 },
+  "failureThreshold" => 3,
+  "periodSeconds" => 5,
+}
+expected_liveness_probe = {
+  "tcpSocket" => { "port" => 3800 },
+  "failureThreshold" => 3,
+  "periodSeconds" => 10,
+  "initialDelaySeconds" => 120,
+}
+
+failures = []
+failures << "unsupported startupProbe is present" if container.key?("startupProbe")
+failures << "command changed" if container.key?("command")
+failures << "args changed" unless container.fetch("args") == expected_args
+failures << "image changed" unless container.fetch("image") == "template-placeholder"
+failures << "ports changed" unless container.fetch("ports") == expected_ports
+failures << "readinessProbe changed" unless container.fetch("readinessProbe") == expected_readiness_probe
+failures << "livenessProbe grace or thresholds changed" unless container.fetch("livenessProbe") == expected_liveness_probe
+
+abort failures.join("\n") unless failures.empty?
+puts "node renderer template preserves supported probe grace and stable runtime settings"
+RUBY
+
 echo "==> parse generated GitHub Actions YAML"
 ruby <<'RUBY'
 require "yaml"


### PR DESCRIPTION
## Why

The review-app renderer template used a probe field unsupported by the deployment provider. Removing it alone would also remove the intended cold-start grace and could let liveness restart the renderer during normal pre-seeding.

This addresses #784. The issue intentionally remains open until the merged default workflow is exercised by a fresh disposable verification PR, behavioral smoke passes, and cleanup is confirmed.

## What changed

- Remove the unsupported startup probe.
- Preserve its intended 120-second startup allowance with the provider-supported liveness initial delay.
- Add a rendered-template regression that locks the supported delay, probe thresholds, runtime arguments, image, and port.

## Workflow change audit

- GitHub workflow files, triggers, permissions, action references, source authorization, and credential-reference shape are byte-identical to the base.
- Readiness behavior and liveness thresholds are unchanged; only the supported liveness delay replaces the unsupported field.
- Security preflight passed; no untrusted issue content was used as instructions.
- Read-only QA and a maker-distinct Sol/xhigh audit found no blocking or discuss findings at the current head.
- The required simplification review completed with no changes.

## Verification

- `bin/conductor-exec bin/test-cpflow-github-flow`
- `bin/conductor-exec .agents/bin/validate` — 58 files, no offenses
- `bin/conductor-exec .agents/bin/test` — 51 RSpec examples and 16 Jest tests, zero failures
- YAML parsing, actionlint, protected-path comparison, and `git diff --check`
- Negative mutations for missing delay, reintroduced unsupported probe, and changed startup command

## Churn and follow-through

- Pre-push review: QA, maker-distinct Sol/xhigh adversarial audit, and simplification gate.
- Post-push fix rounds: 0 at PR creation.
- Process-gap disposition: `checklist+replay` — replay the merged default workflow from a fresh disposable PR before closing #784.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node-renderer startup behavior by delaying readiness checks until the service has had more time to initialize.
  * Removed the startup probe to prevent premature health-status failures.

* **Tests**
  * Added validation to ensure the node-renderer runtime configuration, networking, and health checks remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->