### PR TITLE
Declare direct merge submission policy

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,5 +1,7 @@
 ---
 base_branch: master
+merge_submission:
+  mode: direct
 follow_up_prefix: 'Follow-up:'
 review_gate: n/a
 approval_exempt: n/a


### PR DESCRIPTION
## Why

The shared agent-workflow pack now supports an explicit per-repository merge-submission policy. This repository should record its intended direct submission route in the portable seam.

This changes agent policy YAML only. It does not change the repository's GitHub merge-queue or other settings.

## What changed

- added `merge_submission.mode: direct` to `.agents/agent-workflow.yml`
- changed no other files

## Validation

- baseline merged-source seam doctor — PASS before modification
- YAML safe-load with `merge_submission.mode == direct` assertion — PASS
- merged-source seam doctor after modification — PASS
- `.agents/bin/validate` — PASS (58 files inspected, no RuboCop offenses)
- `git diff --check` — PASS

## Scope notes

- Changelog: not applicable; internal agent workflow policy only
- Benchmarks: not applicable
- The adjacent `jg/agent-workflow-config-seam` branch changes `AGENTS.md`, not this YAML file; the live open-PR inventory showed no `.agents/agent-workflow.yml` collision before publishing.

<details>
<summary>Agent details</summary>

Prepared by Codex from a fresh clone of live `master`. Published as a draft for normal hosted review and validation.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the agent workflow to enable direct merge submission mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->